### PR TITLE
docs(docs/contributors): write contributor documentation from design spec

### DIFF
--- a/website/content/contributors/architecture.mdx
+++ b/website/content/contributors/architecture.mdx
@@ -1,0 +1,286 @@
+---
+title: Architecture
+description: System architecture, layer model, dispatcher flow, and adapter resolution in kall.
+---
+
+kall is structured as a layered system where each layer has a single responsibility and communicates through well-defined interfaces. This page covers the high-level architecture, the dispatcher routing model, and how adapters are resolved at runtime.
+
+## Three-Layer Model
+
+kall separates concerns into three layers:
+
+- **User Layer** — configuration files and the CLI entry point. The user interacts with `kall.yml`, module configs, and the `kall` command.
+- **Core Layer** — shared libraries (`lib/`) and platform adapters that provide a unified API regardless of the underlying OS, display server, or window manager.
+- **Extension Layer** — modules (features), backends (menu launchers), and plugins (external tool integrations) that plug into the core.
+
+```mermaid
+graph TB
+    subgraph User["User Layer"]
+        CLI["kall CLI"]
+        KallYml["~/.config/kall/kall.yml"]
+        ModConfigs["~/.config/kall/config/*.yml"]
+    end
+
+    subgraph Core["Core Layer (~/.local/share/kall/)"]
+        Dispatcher["Dispatcher (kall)"]
+
+        subgraph Lib["lib/"]
+            CoreSh["core.sh"]
+            MenuSh["menu.sh"]
+            PlatformSh["platform.sh"]
+            ThemeSh["theme.sh"]
+            NotifySh["notify.sh"]
+        end
+
+        subgraph Adapters["lib/adapters/"]
+            WMAdapters["wm/ (hyprland, i3, sway, macos, generic)"]
+            NotifyAdapters["notify/ (libnotify, macos, generic)"]
+        end
+    end
+
+    subgraph Backends["backends/"]
+        Rofi["rofi/adapter.sh"]
+        Wofi["wofi/adapter.sh"]
+        Fzf["fzf/adapter.sh"]
+        Others["tofi, fuzzel, dmenu..."]
+    end
+
+    subgraph Modules["modules/"]
+        Power["power/"]
+        Clipboard["clipboard/"]
+        Screenshot["screenshot/"]
+        Groups["groups/*.yml"]
+        OtherMods["... (26 modules)"]
+    end
+
+    subgraph ThemeSystem["Theme System"]
+        Palettes["themes/palettes/*.yml"]
+        GenThemes["generate-themes.sh"]
+        BackendThemes["backends/*/themes/"]
+    end
+
+    CLI --> Dispatcher
+    KallYml --> CoreSh
+    Dispatcher --> CoreSh
+    CoreSh --> MenuSh
+    CoreSh --> PlatformSh
+    CoreSh --> ThemeSh
+    CoreSh --> NotifySh
+    MenuSh --> Rofi & Wofi & Fzf & Others
+    PlatformSh --> WMAdapters
+    NotifySh --> NotifyAdapters
+    Dispatcher --> Power & Clipboard & Screenshot & Groups & OtherMods
+    ThemeSh --> Palettes
+    GenThemes --> BackendThemes
+    Palettes --> GenThemes
+    ModConfigs --> OtherMods
+```
+
+## Core Principles
+
+These rules are non-negotiable and enforced by CI:
+
+1. **Dual display server support.** Every module works on both X11 and Wayland. No exceptions.
+2. **Zero external config dependencies.** kall ships its own defaults for all cosmetic values (font, border radius, icon theme, opacity). It never reads picom, WM themes, or compositor settings. Users override via `kall.yml`. Each appearance property can be set to a value, set to `false` (kall skips it, system handles it), or omitted (default applies).
+3. **Replaceable menu backend.** rofi is the default, not a hard dependency. Any supported launcher is swappable via `kall.yml` without touching module code.
+4. **Self-contained modules.** Modules call lib functions, never platform tools directly. CI greps module scripts for a forbidden tool list (`xclip`, `wl-copy`, `hyprctl`, `maim`, etc.) and fails on violations.
+5. **Bash only.** No Python, Node.js, Ruby, or any language runtime. External standalone binaries like `jq`, `yq`, and `playerctl` are acceptable.
+
+## Dispatcher Flow
+
+The `kall` entry point is purely a router and bootstrapper. It contains no business logic. All functionality lives in `lib/`, `modules/`, or `backends/`.
+
+When you run `kall power`, the dispatcher:
+
+1. Parses flags (`--debug`, `--help`, `--version`)
+2. Sources `lib/core.sh`, which detects the OS, session type, and WM, then parses `kall.yml` and exports all config as environment variables
+3. Sources `lib/platform.sh`, `lib/menu.sh`, `lib/theme.sh`, `lib/notify.sh`, and `lib/keybinds.sh`
+4. Routes the first argument to the correct handler
+
+```mermaid
+flowchart TD
+    Start["kall $1 $@"] --> ParseCore["Source lib/core.sh\n(parse kall.yml, detect env)"]
+    ParseCore --> LoadLibs["Source platform.sh, menu.sh,\ntheme.sh, notify.sh"]
+    LoadLibs --> Route{"Route $1"}
+
+    Route -->|"modules/groups/$1.yml exists"| Group["Load group definition\nShow aggregated menu"]
+    Route -->|"modules/$1/module.yml exists"| Module["Read module.yml\nExec modules/$1/$1.sh"]
+    Route -->|"$1 is CLI command"| Internal["Handle internally\n(add, remove, theme, doctor, etc.)"]
+    Route -->|"none match"| Error["Error: unknown module or command"]
+
+    Group --> SelectMember["User selects member module"]
+    SelectMember --> Module
+
+    Module --> ExecModule["Module executes\nCalls lib/ functions only"]
+    ExecModule --> MenuAdapter["menu.sh delegates\nto active backend adapter"]
+    ExecModule --> PlatAdapter["platform.sh delegates\nto WM/notify adapters"]
+```
+
+The routing priority is:
+
+1. **Group YAML** — if `modules/groups/$1.yml` exists, load the group
+2. **Module script** — if `modules/$1/$1.sh` exists, exec the module
+3. **CLI command** — built-in commands like `list`, `add`, `theme`, `doctor`
+4. **Error** — unknown command or module
+
+From the dispatcher source:
+
+```bash
+# 1. Group YAML
+if [[ -f "$KALL_MODULES_DIR/groups/${cmd}.yml" ]]; then
+  # load and render group menu
+fi
+
+# 2. Module script
+if [[ -f "$KALL_MODULES_DIR/${cmd}/${cmd}.sh" ]]; then
+  exec "$KALL_MODULES_DIR/${cmd}/${cmd}.sh" "$@"
+fi
+
+# 3. CLI commands
+case "$cmd" in
+  list|add|remove|theme|style|keybinds|setup|update|doctor|uninstall|create-module|plugin)
+    # handle internally
+    ;;
+esac
+```
+
+## Adapter Resolution
+
+Modules never call platform tools directly. They call lib functions, which delegate to the appropriate adapter based on the detected environment.
+
+```mermaid
+flowchart LR
+    subgraph Module["Module (e.g., power.sh)"]
+        A1["menu_dmenu()"]
+        A2["clipboard_copy()"]
+        A3["lock_screen()"]
+        A4["notify()"]
+    end
+
+    subgraph Lib["lib/"]
+        B1["menu.sh"]
+        B2["platform.sh"]
+        B3["notify.sh"]
+    end
+
+    subgraph Adapters["Adapters"]
+        C1["backends/rofi/adapter.sh\nOR wofi, fzf, etc."]
+        C2["adapters/wm/hyprland.sh\nOR i3, sway, macos, generic"]
+        C3["adapters/notify/libnotify.sh\nOR macos, generic"]
+    end
+
+    A1 --> B1 --> C1
+    A2 --> B2
+    A3 --> B2 --> C2
+    A4 --> B3 --> C3
+```
+
+Three adapter types are resolved at source time:
+
+| Adapter type | Resolved by | Selection criteria |
+|---|---|---|
+| Menu backend | `lib/menu.sh` | `KALL_MENU_BACKEND` from `kall.yml` (default: `rofi`) |
+| WM adapter | `lib/platform.sh` | `KALL_WM` detected from `XDG_CURRENT_DESKTOP` |
+| Notify adapter | `lib/platform.sh` | OS detection + `notify-send` availability |
+
+If a specific WM adapter is not found, `generic.sh` loads as a safe fallback. The generic adapter implements every interface function with sensible defaults so that an unknown WM never prevents kall from running.
+
+## Invariants
+
+The system maintains invariants that CI validates on every PR. See the full list in the [design spec](/docs/superpowers/specs/2026-03-14-kall-design), but the key categories are:
+
+- **Module invariants** — every module has `module.yml` + entry script + test file, no direct platform tool calls, dual display server support
+- **Backend invariants** — every backend implements the full [menu adapter interface](/contributors/backend-adapters), `menu_supports()` reports accurate capabilities
+- **Platform invariants** — every `lib/platform.sh` function works on X11, Wayland, and macOS; the generic WM adapter implements the full interface; all adapter functions are idempotent
+- **Config invariants** — `kall.yml` validates against its schema, kall starts with empty config, every appearance property accepts three states (value, `false`, absent)
+- **Theme invariants** — every palette defines the complete set of required color variables, `generate-themes.sh` produces valid output for any palette, wallbash falls back to static palette on failure
+
+## Value Resolution
+
+Configuration values flow through a layered resolution chain:
+
+1. **Command-line flags** (`--debug`) override everything
+2. **Environment variables** (`KALL_LOG_LEVEL=TRACE`) override config file values
+3. **`kall.yml`** user configuration
+4. **Built-in defaults** hardcoded in `lib/core.sh`
+
+From `lib/core.sh`, the `_kall_read_config` function handles this gracefully:
+
+```bash
+_kall_read_config() {
+  local key="$1"
+  local default="${2:-}"
+
+  # No config file? Return default.
+  if [[ ! -f "$KALL_CONFIG_FILE" ]]; then
+    echo "$default"
+    return
+  fi
+
+  # No yq? Return default.
+  if ! command -v yq &>/dev/null; then
+    echo "$default"
+    return
+  fi
+
+  local value
+  value="$(yq ".$key" "$KALL_CONFIG_FILE" 2>/dev/null)" || {
+    echo "$default"
+    return
+  }
+
+  # yq returns literal "null" for missing keys
+  if [[ -z "$value" || "$value" == "null" ]]; then
+    echo "$default"
+    return
+  fi
+
+  echo "$value"
+}
+```
+
+This ensures kall starts successfully with a completely empty or missing `kall.yml` by falling back to built-in defaults for every value.
+
+## Directory Structure
+
+The installed kall tree lives at `~/.local/share/kall/`:
+
+```
+~/.local/share/kall/
+├── kall                    # dispatcher (symlinked to PATH)
+├── lib/                    # shared infrastructure
+│   ├── core.sh             # env detection, config parsing
+│   ├── log.sh              # structured logging + rotation
+│   ├── menu.sh             # loads backend adapter
+│   ├── platform.sh         # clipboard, screenshot, wallpaper
+│   ├── theme.sh            # palette loader + wallbash
+│   ├── notify.sh           # notification wrappers
+│   ├── keybinds.sh         # keybinding translation
+│   └── adapters/
+│       ├── wm/             # hyprland, i3, sway, bspwm, dwm, macos, generic
+│       └── notify/         # libnotify, macos, generic
+├── backends/               # menu launcher backends
+│   ├── rofi/adapter.sh
+│   ├── wofi/adapter.sh
+│   ├── fzf/adapter.sh
+│   └── ...
+├── modules/                # pluggable feature modules
+│   ├── power/
+│   ├── clipboard/
+│   └── ...
+├── themes/palettes/        # backend-agnostic color definitions
+├── schemas/                # YAML validation schemas
+└── tests/                  # BATS test suite
+```
+
+User configuration lives separately at `~/.config/kall/`:
+
+```
+~/.config/kall/
+├── kall.yml                # main configuration
+└── config/                 # per-module user configs
+    ├── websearch.yml
+    └── ...
+```
+
+This separation means the source tree is never edited by the user, and user config is never overwritten by updates.

--- a/website/content/contributors/backend-adapters.mdx
+++ b/website/content/contributors/backend-adapters.mdx
@@ -1,0 +1,274 @@
+---
+title: Backend Adapters
+description: Menu adapter interface, capability matrix, theme generation, and how to add a new backend.
+---
+
+Backend adapters are the bridge between kall's module system and the actual menu launcher that renders on screen. Each backend is a self-contained directory under `backends/` that implements a standard interface. This page covers the menu adapter interface, capability reporting, the theme generation pipeline, and how to write a new backend.
+
+## Menu Adapter Interface
+
+Every backend must implement five functions. `lib/menu.sh` validates this at source time and calls `log_fatal` if any function is missing:
+
+```bash
+_kall_menu_required_functions=(
+  menu_dmenu
+  menu_launch
+  menu_calc
+  menu_keys
+  menu_supports
+)
+
+for _kall_fn in "${_kall_menu_required_functions[@]}"; do
+  if ! declare -f "$_kall_fn" &>/dev/null; then
+    log_fatal "menu.sh: backend '$KALL_MENU_BACKEND' missing required function: $_kall_fn"
+  fi
+done
+```
+
+### Function Signatures
+
+#### `menu_dmenu [OPTIONS]`
+
+The primary menu function. Reads newline-separated items from stdin and returns the selected item on stdout.
+
+| Parameter | Description |
+|---|---|
+| `-p PROMPT` | Prompt string displayed in the menu |
+| `-l LINES` | Number of visible lines/rows |
+| `-i` | Case-insensitive matching |
+| `-layout NAME` | Layout template name (e.g., `clipboard`, `selector`) |
+
+**Return values:**
+- Exit code `0` with the selected option on stdout on success
+- Exit code `1` on user cancel/escape
+- No other exit codes are valid (invariant INV-BE-03)
+
+**Example usage by a module:**
+
+```bash
+choice=$(printf "Shutdown\nReboot\nLock\nSuspend\nLogout" | menu_dmenu -p "Power" -layout "clipboard")
+```
+
+#### `menu_launch [OPTIONS]`
+
+Application launcher mode. Displays installed applications and runs the selected one.
+
+| Parameter | Description |
+|---|---|
+| `-modi MODES` | Comma-separated modes (e.g., `drun,run,window`) |
+| `-layout NAME` | Layout template name |
+
+Not all backends support this. Backends that do not should display a warning via `log_warn` and return `1`.
+
+#### `menu_calc`
+
+Calculator mode. Accepts arithmetic expressions and returns results.
+
+Only rofi supports this natively. Other backends should return `1` and log a warning.
+
+#### `menu_keys [OPTIONS]`
+
+Keyboard shortcut display mode. Used by the keybindings module to show WM keybinding cheat sheets.
+
+| Parameter | Description |
+|---|---|
+| `-config FILE` | Keybinding config file to display |
+
+#### `menu_supports CAPABILITY`
+
+Capability query function. Returns `0` (true) if the backend supports the given capability, `1` (false) otherwise. This function must return accurate information (invariant INV-BE-02).
+
+```bash
+if menu_supports "icons"; then
+  # format items with icons
+fi
+```
+
+## Capability Matrix
+
+| Capability | rofi | wofi | fuzzel | tofi | dmenu | fzf |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| `icons` | Yes | Yes | Yes | No | No | Partial |
+| `markup` | Yes (pango) | No | No | No | No | Partial (ANSI) |
+| `blocks` | Yes | No | No | No | No | Yes (reload) |
+| `calc` | Yes | No | No | No | No | No |
+| `launch` | Yes | Yes | Yes | No | No | No |
+| `preview` | No | No | No | No | No | Yes |
+
+Modules use `menu_supports` to check capabilities and degrade gracefully. For example, a module that benefits from icon support will still work on dmenu, just without icons. See [capability-aware degradation](/contributors/module-system#capability-aware-degradation) for patterns.
+
+## Backend Loading
+
+`lib/menu.sh` loads exactly one backend adapter based on `KALL_MENU_BACKEND`:
+
+```bash
+KALL_BACKENDS_DIR="${KALL_BACKENDS_DIR:-$(cd "$KALL_LIB_DIR/.." && pwd)/backends}"
+
+_kall_menu_adapter="$KALL_BACKENDS_DIR/$KALL_MENU_BACKEND/adapter.sh"
+
+if [[ ! -f "$_kall_menu_adapter" ]]; then
+  log_fatal "menu.sh: backend adapter not found: $_kall_menu_adapter"
+fi
+
+source "$_kall_menu_adapter"
+```
+
+The `KALL_MENU_BACKEND` value comes from `kall.yml` (default: `rofi`):
+
+```yaml
+# ~/.config/kall/kall.yml
+menu_backend: rofi    # rofi | wofi | tofi | fuzzel | dmenu | fzf
+```
+
+## Theme Generation Pipeline
+
+One canonical palette YAML drives theme generation for all backends. The `backends/generate-themes.sh` script reads a palette and produces backend-specific theme files:
+
+```mermaid
+flowchart LR
+    Palette["themes/palettes/\ncatppuccin-mocha.yml"] --> Generator["backends/\ngenerate-themes.sh"]
+
+    Generator --> RofiTheme["backends/rofi/themes/\ntheme.rasi + layouts"]
+    Generator --> WofiTheme["backends/wofi/themes/\ntheme.css"]
+    Generator --> TofiTheme["backends/tofi/themes/\ntheme.ini"]
+    Generator --> FzfTheme["backends/fzf/themes/\ntheme.sh"]
+    Generator --> DmenuTheme["backends/dmenu/themes/\ntheme.sh"]
+    Generator --> FuzzelTheme["backends/fuzzel/themes/\ntheme.ini"]
+
+    Wallpaper["Current wallpaper"] -->|"wallbash enabled"| ImageMagick["ImageMagick\ncolor extraction"]
+    ImageMagick --> DynPalette["Dynamic palette YAML"]
+    DynPalette --> Generator
+```
+
+### Generated Theme File Formats
+
+| Backend | Format | File | What it contains |
+|---|---|---|---|
+| rofi | Rasi | `theme.rasi` + layout files | Colors, fonts, window geometry |
+| wofi | CSS | `theme.css` | CSS variables for colors and sizing |
+| tofi | INI | `theme.ini` | Key-value color and font settings |
+| fuzzel | INI | `theme.ini` | Key-value color settings |
+| dmenu | Shell | `theme.sh` | Exports `-nb`, `-nf`, `-sb`, `-sf` color args |
+| fzf | Shell | `theme.sh` | Exports `FZF_DEFAULT_OPTS --color` string |
+
+### Color Variable Mapping
+
+The generator reads these canonical color variables from palette YAML and maps them to backend-specific formats:
+
+| Palette key | Purpose | Example (Catppuccin Mocha) |
+|---|---|---|
+| `main_bg` | Primary background | `#1E1E2E` |
+| `main_fg` | Primary foreground/text | `#CDD6F4` |
+| `main_br` | Border/accent | `#CBA6F7` |
+| `main_ex` | Extra/highlight | `#F5E0DC` |
+| `select_bg` | Selected item background | `#B4BEFE` |
+| `select_fg` | Selected item foreground | `#1E1E2E` |
+| `urgent_bg` | Urgent/error background | `#F38BA8` |
+| `urgent_fg` | Urgent/error foreground | `#1E1E2E` |
+
+These are exported at runtime as `KALL_COLOR_*` environment variables by `lib/theme.sh`. The backend adapter reads them when applying the theme.
+
+## Backend Directory Structure
+
+Each backend follows this layout:
+
+```
+backends/rofi/
+├── adapter.sh              # menu adapter implementation
+├── themes/
+│   ├── theme.rasi          # active color theme
+│   ├── style_{1..12}.rasi  # 12 launcher layout styles
+│   ├── clipboard.rasi      # small dropdown layout
+│   ├── simple.rasi         # single-column layout
+│   ├── selector.rasi       # icon grid layout
+│   ├── searchbar.rasi      # fullscreen search overlay
+│   ├── launchpad.rasi      # fullscreen app grid
+│   └── wallpaper-slider.rasi
+└── README.md
+```
+
+Layout files are backend-specific templates that control the visual arrangement of a menu. They live under `backends/<name>/themes/` and are referenced by the `layout` field in `module.yml`.
+
+## Backend Invariants
+
+- **INV-BE-01:** Every directory under `backends/` must contain an `adapter.sh` that implements the full menu adapter interface
+- **INV-BE-02:** `menu_supports()` must return accurate capability information. A backend must not claim support for a capability it does not implement
+- **INV-BE-03:** `menu_dmenu()` must return exit code `0` with the selected option on stdout on success, and exit code `1` on user cancel/escape. No other exit codes are valid
+- **INV-BE-04:** Backend adapters must not access module internals. The adapter interface is the only contract between backends and modules
+
+## How to Add a New Backend
+
+1. **Create the backend directory:**
+
+```
+backends/mybackend/
+├── adapter.sh
+├── themes/
+│   └── theme.<ext>
+└── README.md
+```
+
+2. **Implement all five interface functions** in `adapter.sh`:
+
+```bash
+#!/usr/bin/env bash
+# backends/mybackend/adapter.sh
+
+menu_dmenu() {
+  local prompt="" lines="" layout="" case_insensitive=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -p) prompt="$2"; shift 2 ;;
+      -l) lines="$2"; shift 2 ;;
+      -i) case_insensitive=1; shift ;;
+      -layout) layout="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  # Read items from stdin, present menu, write selection to stdout
+  # Return 0 on selection, 1 on cancel
+}
+
+menu_launch() {
+  # Application launcher mode
+  log_warn "mybackend: menu_launch not supported"
+  return 1
+}
+
+menu_calc() {
+  log_warn "mybackend: menu_calc not supported"
+  return 1
+}
+
+menu_keys() {
+  log_warn "mybackend: menu_keys not supported"
+  return 1
+}
+
+menu_supports() {
+  local capability="$1"
+  case "$capability" in
+    icons)   return 1 ;;
+    markup)  return 1 ;;
+    blocks)  return 1 ;;
+    calc)    return 1 ;;
+    launch)  return 1 ;;
+    preview) return 1 ;;
+    *)       return 1 ;;
+  esac
+}
+```
+
+3. **Add theme generation** to `backends/generate-themes.sh` so that palettes produce valid theme files for your backend.
+
+4. **Handle layout hints.** Your `menu_dmenu` implementation should translate [layout hints](/contributors/module-system#layout-hints) from `module.yml` into backend-specific rendering (columns, icon size, preview commands, etc.).
+
+5. **Handle the `managed: false` appearance mode.** When `KALL_APPEARANCE_MANAGED` is `false`, skip all styling arguments and let the user's own backend configuration control appearance.
+
+6. **Handle missing optional dependencies gracefully.** For example, if your backend supports image preview but the required tool is not installed, fall back to text-only rendering.
+
+7. **Write tests** covering all five interface functions and capability reporting accuracy.
+
+8. **Update documentation** to include the new backend in the capability matrix.

--- a/website/content/contributors/ci-cd.mdx
+++ b/website/content/contributors/ci-cd.mdx
@@ -1,0 +1,432 @@
+---
+title: CI/CD
+description: GitHub Actions workflows, git hooks, commit conventions, label system, and automation.
+---
+
+kall uses GitHub Actions for continuous integration and release automation, lefthook for local git hooks, and a Kubernetes-inspired label system for issue and PR organization. This page covers the full CI/CD pipeline, commit message format, and label taxonomy.
+
+## GitHub Actions Workflows
+
+Five workflows automate testing, validation, releasing, and maintenance:
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `ci.yml` | PR to main, push to main | Lint, test matrix, structural validation |
+| `release.yml` | Tag push | Full CI, changelog, GitHub Release, AUR/Homebrew push, docs deploy |
+| `docs-deploy.yml` | Push to main | Deploy fumadocs site |
+| `module-validate.yml` | PR | Validate module.yml schemas and forbidden tool calls |
+| `stale.yml` | Schedule | Auto-close stale issues and PRs |
+
+### ci.yml
+
+The primary CI workflow runs three jobs in parallel:
+
+**lint** — static analysis on all `.sh` files (excluding test helpers):
+
+```yaml
+lint:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Install tools
+      run: sudo apt-get install -y shellcheck && curl -sS https://webinstall.dev/shfmt | bash
+    - name: Shellcheck
+      run: find . -name '*.sh' -not -path '*/test_helper/*' -not -path '*/.claude/*' | xargs shellcheck
+    - name: shfmt
+      run: find . -name '*.sh' -not -path '*/test_helper/*' -not -path '*/.claude/*' | xargs shfmt -d -i 2 -ci
+```
+
+Shellcheck catches common bash pitfalls (unquoted variables, unreachable code, incorrect test syntax). shfmt enforces consistent formatting with 2-space indentation and case statement indentation (`-ci`).
+
+**test** — runs the full BATS test suite across a platform/session matrix:
+
+```yaml
+test:
+  runs-on: ${{ matrix.os }}
+  strategy:
+    matrix:
+      os: [ubuntu-22.04, ubuntu-24.04, macos-14]
+      session: [x11, wayland]
+      exclude:
+        - os: macos-14
+          session: x11
+        - os: macos-14
+          session: wayland
+      include:
+        - os: macos-14
+          session: darwin
+  steps:
+    - uses: actions/checkout@v4
+    - name: Install BATS
+      run: |
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          brew install bats-core
+        else
+          sudo apt-get install -y bats
+        fi
+    - name: Run tests
+      env:
+        XDG_SESSION_TYPE: ${{ matrix.session }}
+      run: ./tests/run_tests.sh
+```
+
+This produces five test runs: Ubuntu 22.04 (x11), Ubuntu 22.04 (wayland), Ubuntu 24.04 (x11), Ubuntu 24.04 (wayland), and macOS 14 (darwin). The `XDG_SESSION_TYPE` variable controls which platform code paths the tests exercise.
+
+**validate** — structural checks that enforce project invariants:
+
+```yaml
+validate:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Check modules have tests
+      run: |
+        status=0
+        for dir in modules/*/; do
+          [ -d "$dir" ] || continue
+          name=$(basename "$dir")
+          [[ "$name" == "groups" ]] && continue
+          if [ ! -f "tests/test_${name}.bats" ]; then
+            echo "FAIL: modules/$name/ missing test file"
+            status=1
+          fi
+        done
+        exit $status
+    - name: Check no direct platform tool calls
+      run: |
+        forbidden="xclip\|wl-copy\|wl-paste\|grim\|maim\|hyprctl\|i3-msg\|i3lock\|swaymsg\|pbcopy\|pbpaste\|screencapture\|xdotool\|xrandr"
+        if grep -rn "$forbidden" modules/ --include='*.sh' 2>/dev/null | grep -v '#'; then
+          echo "FAIL: modules contain direct platform tool calls"
+          exit 1
+        fi
+        echo "OK: no forbidden tool calls"
+```
+
+The validation job enforces two critical invariants:
+- **INV-MOD-02:** every module has a test file
+- **INV-MOD-03:** no module directly calls platform-specific tools
+
+### release.yml
+
+Triggered when a version tag is pushed (e.g., `v2.1.0`). The release pipeline:
+
+1. Runs the full CI suite (lint + test + validate)
+2. Generates a changelog from conventional commits since the last tag
+3. Creates a GitHub Release with a `.tar.gz` tarball
+4. Pushes updated package definitions to AUR and Homebrew tap
+5. Deploys the documentation site
+
+### Labeler Workflow
+
+The `labeler.yml` workflow runs on `issues.opened`, `issues.edited`, `pull_request.opened`, `pull_request.synchronize`, and `pull_request.edited`. It uses path-based rules and commit message parsing to auto-apply labels.
+
+## Git Hooks (lefthook)
+
+Local git hooks are managed by lefthook and defined in `lefthook.yml`. Three hooks enforce code quality before code reaches CI:
+
+### pre-commit
+
+Runs shellcheck and shfmt in parallel on staged `.sh` files:
+
+```yaml
+pre-commit:
+  parallel: true
+  commands:
+    shellcheck:
+      glob: "*.sh"
+      run: shellcheck {staged_files}
+    shfmt:
+      glob: "*.sh"
+      run: shfmt -d -i 2 -ci {staged_files}
+```
+
+Both tools run only on staged files, not the entire repo. This keeps the hook fast. If either tool reports errors, the commit is rejected.
+
+### commit-msg
+
+Validates that the commit message follows the conventional format:
+
+```yaml
+commit-msg:
+  commands:
+    conventional:
+      run: |
+        msg=$(head -1 "$1")
+        pattern='^(feat|fix|refactor|test|docs|chore|ci|perf|style|build)\((module|backend|plugin|lib|theme|installer|cli|docs|ci|schema)/[a-z0-9_-]+\): .+$'
+        if ! echo "$msg" | grep -qE "$pattern"; then
+          echo "ERROR: Commit message must match: type(area/name): description"
+          echo "  Types: feat, fix, refactor, test, docs, chore, ci, perf, style, build"
+          echo "  Areas: module, backend, plugin, lib, theme, installer, cli, docs, ci, schema"
+          echo "  Example: feat(module/clipboard): add image history support"
+          echo "  Got: $msg"
+          exit 1
+        fi
+```
+
+The regex requires the full `type(area/name): description` format. Bare scopes like `feat(clipboard)` without the area prefix are rejected.
+
+### pre-push
+
+Runs the full BATS test suite before pushing:
+
+```yaml
+pre-push:
+  commands:
+    tests:
+      run: ./tests/run_tests.sh
+```
+
+This ensures all tests pass locally before changes reach the remote. Catches issues that shellcheck and shfmt do not cover.
+
+## Commit Conventions
+
+Every commit message must follow the format:
+
+```
+type(area/name): description
+```
+
+### Types
+
+| Type | When to use |
+|---|---|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `refactor` | Code restructuring without behavior change |
+| `test` | Adding or updating tests |
+| `docs` | Documentation changes |
+| `chore` | Maintenance tasks (deps, config, cleanup) |
+| `ci` | CI/CD pipeline changes |
+| `perf` | Performance improvement |
+| `style` | Formatting, whitespace, code style (no logic change) |
+| `build` | Build system or packaging changes |
+
+### Areas
+
+| Area | What it covers | Example scope |
+|---|---|---|
+| `module` | A specific module | `module/clipboard`, `module/power` |
+| `backend` | A menu backend adapter | `backend/rofi`, `backend/fzf` |
+| `plugin` | A plugin integration | `plugin/tmux`, `plugin/waybar` |
+| `lib` | Shared library code | `lib/platform`, `lib/menu` |
+| `theme` | Palettes, theme engine, wallbash | `theme/wallbash`, `theme/dracula` |
+| `installer` | Installer wizard | `installer/wizard`, `installer/deps` |
+| `cli` | Dispatcher, CLI commands | `cli/dispatcher`, `cli/doctor` |
+| `docs` | Documentation, website | `docs/module-authors`, `docs/readme` |
+| `ci` | GitHub Actions, hooks, CI config | `ci/release`, `ci/matrix` |
+| `schema` | YAML schemas | `schema/module`, `schema/palette` |
+
+### Examples
+
+```
+feat(module/clipboard): add image history support
+fix(module/power): hyprlock fallback when swaylock missing
+feat(backend/fzf): add chafa image preview support
+fix(backend/rofi): theme path resolution on macOS
+feat(plugin/waybar): add media now-playing module
+refactor(lib/platform): extract macOS clipboard adapter
+feat(theme/wallbash): add ImageMagick color quantization
+docs(docs/module-authors): add testing guide
+test(module/screenshot): add wayland mock tests
+chore(ci/release): add AUR push step
+fix(cli/doctor): false positive on optional deps
+feat(schema/module): add layout_hints validation
+```
+
+### CHANGELOG Generation
+
+`CHANGELOG.md` is auto-generated from conventional commits at release time. Entries are grouped by area:
+
+```markdown
+## [2.1.0] - 2026-04-15
+
+### Modules
+- **feat(module/clipboard):** add image history support
+- **fix(module/power):** hyprlock fallback when swaylock missing
+
+### Backends
+- **feat(backend/fzf):** add chafa image preview support
+
+### Plugins
+- **feat(plugin/waybar):** add media now-playing module
+
+### Lib
+- **refactor(lib/platform):** extract macOS clipboard adapter
+
+### Theme
+- **feat(theme/wallbash):** add ImageMagick color quantization
+```
+
+The `RELEASE.md` file included in GitHub Releases is a user-facing subset that only includes `feat`, `fix`, and `breaking` types. Internal changes (`refactor`, `test`, `chore`, `ci`) are excluded.
+
+## Label System
+
+kall uses a Kubernetes-inspired label taxonomy with `/` prefix namespacing. All label definitions live in `.github/labels.yml` and are synced to the repository via CI.
+
+### Label Categories
+
+**`kind/`** — classifies the type of issue or PR:
+
+| Label | Description |
+|---|---|
+| `kind/bug` | Something is not working |
+| `kind/feature` | New feature or enhancement request |
+| `kind/docs` | Documentation improvements |
+| `kind/breaking` | Breaking change to API, config, or CLI |
+
+**`area/`** — identifies which part of the system is affected. Maps directly to commit convention areas:
+
+| Label | Description |
+|---|---|
+| `area/module` | Related to modules |
+| `area/backend` | Related to backends (rofi, wofi, dmenu, etc.) |
+| `area/plugin` | Related to plugins |
+| `area/lib` | Related to core libraries |
+| `area/theme` | Related to themes and palettes |
+| `area/installer` | Related to the installer |
+| `area/ci` | Related to CI/CD and GitHub Actions |
+| `area/schema` | Related to YAML schemas and validation |
+| `area/docs` | Related to documentation and website |
+
+**Component labels** — specific component within an area. Applied alongside `area/`:
+
+- `component/clipboard`, `component/screenshot`, `component/wallpaper`, `component/power`
+- Additional component labels are generated from directory listings
+
+**`platform/`** — which platform is affected:
+
+| Label | Description |
+|---|---|
+| `platform/linux-x11` | Linux X11 specific |
+| `platform/linux-wayland` | Linux Wayland specific |
+| `platform/macos` | macOS specific |
+
+**`priority/`** — urgency:
+
+| Label | Description |
+|---|---|
+| `priority/critical` | Blocks release or breaks core functionality |
+| `priority/high` | Should be fixed in this release cycle |
+| `priority/backlog` | Agreed on need, not yet scheduled |
+
+**`size/`** — PR size (auto-applied by CI):
+
+| Label | Line count |
+|---|---|
+| `size/xs` | < 10 lines |
+| `size/s` | 10-50 lines |
+| `size/m` | 50-200 lines |
+| `size/l` | 200-500 lines |
+| `size/xl` | 500+ lines |
+
+**`triage/`** — triage status:
+
+| Label | Description |
+|---|---|
+| `triage/needs-info` | Needs more information from reporter |
+| `triage/accepted` | Issue has been triaged and accepted |
+| `triage/duplicate` | Duplicate of another issue |
+
+**`do-not-merge/`** — merge blockers:
+
+| Label | Description |
+|---|---|
+| `do-not-merge/wip` | Work in progress, not ready for merge |
+| `do-not-merge/needs-rebase` | PR needs rebase before merging |
+| `do-not-merge/hold` | PR is on hold |
+
+**Community labels:**
+
+| Label | Description |
+|---|---|
+| `good first issue` | Good for newcomers |
+| `help wanted` | Extra attention is needed |
+| `hacktoberfest` | Hacktoberfest eligible |
+
+### Total Label Count
+
+Approximately 50 labels: 4 kind + 10 area + ~30 component + 3 platform + 3 priority + 5 size + 3 triage + 3 do-not-merge + 3 community. The count grows only when new modules, backends, or plugins are added.
+
+### What We Intentionally Exclude
+
+- No `lifecycle/` labels — the stale bot uses time-based rules, not labels
+- No `needs-*` labels — issue templates enforce required fields, CI blocks invalid commits
+- No `kind/support` — support goes to Discussions, not Issues
+- No `kind/deprecation` or `kind/failing-test` — `kind/bug` covers test failures, deprecation is `kind/breaking` with a migration path
+- No `priority/awaiting-more-evidence` — that is `triage/needs-info`
+
+## Label Automation
+
+Labels are applied automatically through three mechanisms:
+
+### Path-Based Auto-Labeling
+
+The `labeler.yml` workflow uses `actions/labeler` with path-based rules to apply `area/` and component labels to PRs:
+
+```yaml
+# .github/labeler.yml (path rules)
+area/module:
+  - modules/**
+area/backend:
+  - backends/**
+area/plugin:
+  - plugins/**
+area/lib:
+  - lib/**
+area/theme:
+  - themes/**
+  - backends/*/themes/**
+area/installer:
+  - installer/**
+area/cli:
+  - kall
+area/docs:
+  - website/**
+area/ci:
+  - .github/**
+area/schema:
+  - schemas/**
+
+# Component-level auto-labels
+module/power:
+  - modules/power/**
+module/clipboard:
+  - modules/clipboard/**
+backend/rofi:
+  - backends/rofi/**
+backend/fzf:
+  - backends/fzf/**
+plugin/zsh:
+  - plugins/zsh/**
+plugin/tmux:
+  - plugins/tmux/**
+```
+
+### Issue Template Labels
+
+GitHub issue forms set labels via the `labels:` field in the template YAML. When a user selects the bug report template, `kind/bug` is auto-applied. Feature requests get `kind/feature`, and so on.
+
+### Stale Automation
+
+| Event | Action |
+|---|---|
+| No activity for 60 days | Bot posts warning comment |
+| No activity for 90 days | Bot closes issue |
+| `priority/critical` label | Exempt from stale automation |
+
+### PR Auto-Labels
+
+| Trigger | Labels applied |
+|---|---|
+| PR diff size | `size/xs` through `size/xl` |
+| Files changed match path patterns | `area/*` + component labels |
+| Commit message scopes | `area/*` + component labels parsed from conventional commits |
+| PR is draft | `do-not-merge/wip` (auto-removed when undrafted) |
+
+## Issue and PR Templates
+
+The project uses three types of templates:
+
+- **Issues:** bug report (YAML form), feature request (YAML form), module proposal (YAML form)
+- **PRs:** default, new module, bugfix
+- **Discussions:** ideas, show-and-tell (custom modules), Q&A

--- a/website/content/contributors/distribution.mdx
+++ b/website/content/contributors/distribution.mdx
@@ -1,0 +1,201 @@
+---
+title: Distribution
+description: Distribution channels, release pipeline, versioning strategy, and versioned documentation.
+---
+
+kall ships as bash scripts and assets with no compiled binaries. Distribution covers five channels, a tag-triggered release pipeline, semver versioning, and versioned documentation powered by fumadocs. This page explains how releases are built, published, and documented.
+
+## Distribution Channels
+
+kall is available through multiple channels, each targeting a different installation preference:
+
+| Channel | Install command | Target version | Notes |
+|---|---|---|---|
+| curl installer | `curl -fsSL kall.sh/install \| bash` | v2.0 | Interactive wizard with module/theme selection |
+| AUR | `yay -S kall` | v2.0 | Arch Linux, post-install runs `kall setup` |
+| Homebrew | `brew install shaiknoorullah/tap/kall` | v2.0 | macOS (and Linux via Homebrew) |
+| GitHub Release | `.tar.gz` from Releases page | v2.0 | Manual download and extraction |
+| Debian/Ubuntu (PPA) | `apt install kall` | v2.1+ (future) | Planned for a later release |
+
+All distribution packages contain the same contents: bash scripts, YAML config files, palette definitions, and theme assets. No compilation step is involved.
+
+### curl Installer
+
+The primary installation method. Running the curl command launches an interactive wizard that:
+
+1. **Detects the system** — OS, display server, window manager, package manager, shell
+2. **Bootstraps framework dependencies** — installs a menu launcher (user picks which), `yq`, and `jq`
+3. **Module selection** — presents modules grouped by category with presets (minimal: 5, standard: 15, full: 26)
+4. **Theme selection** — pick palette and launcher style, option to enable wallbash
+5. **Dependency resolution** — aggregates deps from selected modules, shows missing, asks to install
+6. **Install and configure** — clones the repo, generates `kall.yml`, generates theme files, symlinks the CLI, copies user configs
+7. **Summary** — prints what was installed, suggested keybindings for the detected WM, and `kall doctor` results
+
+A non-interactive mode is available for scripted installs and CI:
+
+```bash
+curl -fsSL kall.sh/install | bash -s -- \
+  --non-interactive \
+  --preset standard \
+  --backend rofi \
+  --theme catppuccin-mocha \
+  --style style_1 \
+  --no-wallbash
+```
+
+#### Package Manager Detection
+
+The installer auto-detects the system's package manager:
+
+| Distro | Package manager | Elevation | AUR helper |
+|---|---|---|---|
+| Arch Linux | pacman | `sudo pacman -S` | auto-detects paru > yay > pacman |
+| Ubuntu/Debian | apt | `sudo apt install` | n/a |
+| Fedora | dnf | `sudo dnf install` | n/a |
+| macOS | Homebrew | `brew install` (no sudo) | n/a |
+
+#### Elevation Handling
+
+The installer enforces strict elevation rules per invariant INV-INS-01:
+
+- Never runs as root
+- Uses `sudo` only for package installation commands
+- Prints exactly what it will install and asks for confirmation before the first `sudo` call
+- If `sudo` is unavailable or the user denies, prints manual install commands and continues
+- On macOS, Homebrew does not require sudo
+
+#### Missing Package Handling
+
+When a required dependency is not in the detected package manager's repositories, the installer prints a warning with manual install instructions (build from source URL, alternative package name) and continues. `kall doctor` shows any unresolved dependencies after installation.
+
+### AUR Package
+
+The AUR package installs the full kall source tree. After installation, users run `kall setup` to select modules and pick a theme. The setup wizard is the same as steps 3-7 of the curl installer.
+
+### Homebrew Formula
+
+The Homebrew formula installs kall via the `shaiknoorullah/tap` tap. It handles all dependencies through Homebrew's dependency system. Post-install runs `kall setup`.
+
+### GitHub Release
+
+Each tagged release publishes a `.tar.gz` archive containing the full source tree. Users download, extract, and run `./install.sh` from the extracted directory. This is the fallback for systems without a supported package manager.
+
+### Debian/Ubuntu (Future)
+
+A `.deb` package distributed through a PPA is planned for v2.1+. This will use the standard Debian packaging workflow with `dpkg-buildpackage`.
+
+## Release Pipeline
+
+Releases are automated through the `release.yml` GitHub Actions workflow, triggered by pushing a version tag.
+
+### Tag Trigger
+
+When a tag matching `v*` is pushed (e.g., `v2.1.0`), the release pipeline starts:
+
+```
+git tag v2.1.0
+git push origin v2.1.0
+```
+
+### Pipeline Steps
+
+1. **Full CI** — runs the complete `ci.yml` suite (lint, test matrix, validate). If any job fails, the release is aborted.
+
+2. **Changelog generation** — generates `CHANGELOG.md` entries from conventional commits since the previous tag. Commits are grouped by area (Modules, Backends, Plugins, Lib, Theme, etc.).
+
+3. **RELEASE.md generation** — creates a user-facing release summary. Only `feat`, `fix`, and `breaking` commit types appear. Internal changes (`refactor`, `test`, `chore`, `ci`) are excluded.
+
+4. **GitHub Release** — creates a release on GitHub with:
+   - The version tag as the release name
+   - `RELEASE.md` content as the release body
+   - A `.tar.gz` tarball of the source tree attached as an asset
+
+5. **AUR push** — updates the `PKGBUILD` in the AUR repository with the new version number and SHA256 hash, then pushes.
+
+6. **Homebrew push** — updates the formula in `shaiknoorullah/homebrew-tap` with the new version URL and SHA256 hash, then pushes.
+
+7. **Docs deploy** — deploys the fumadocs site with updated version information.
+
+### Release Artifacts
+
+Each release produces:
+
+| Artifact | Contents |
+|---|---|
+| `kall-<version>.tar.gz` | Full source tree (bash scripts, palettes, schemas, assets) |
+| `CHANGELOG.md` | Cumulative changelog for all versions |
+| `RELEASE.md` | User-facing summary for this release only |
+
+## Versioning
+
+kall follows semantic versioning (semver). The version number has three components: `major.minor.patch`.
+
+### Version Levels
+
+| Level | Format | When | Example |
+|---|---|---|---|
+| Patch | `2.0.x` | Bug fixes, documentation updates, typos | Fix clipboard on Ubuntu 24.04 |
+| Minor | `2.x.0` | New modules, new lib functions, new themes, non-breaking additions | Add weather module |
+| Major | `x.0.0` | Breaking changes to `module.yml` format, lib API, CLI interface, or `kall.yml` keys | Rename kall.yml keys |
+
+### What Counts as Breaking
+
+A change is breaking if it requires users or module authors to modify their existing configuration or code:
+
+- Renaming or removing keys in `kall.yml`
+- Changing the `module.yml` contract (required fields, field semantics)
+- Renaming or removing `lib/` API functions
+- Changing CLI command names or argument semantics
+- Changing the palette YAML format
+
+Non-breaking additions (new optional keys, new modules, new lib functions) are minor version bumps even if they add significant functionality.
+
+### Version in kall.yml
+
+The user's `kall.yml` includes a version field:
+
+```yaml
+version: "2.0.0"
+```
+
+This allows `kall doctor` to detect config files from older versions and suggest migration steps.
+
+## Versioned Documentation
+
+The documentation site uses fumadocs with version support. When a new major version ships, the documentation is versioned.
+
+### Version Behavior
+
+| Scenario | URL | What is shown |
+|---|---|---|
+| Current version | `/docs` | Latest major version documentation |
+| Previous version | `/docs/v2` | Archived v2.x documentation |
+| Version switcher | Dropdown in docs nav | Lists all available versions |
+
+### Version Switcher
+
+The fumadocs version switcher appears as a dropdown in the documentation navigation. Users can switch between major versions to see documentation relevant to their installed version.
+
+### Migration Guides
+
+When a major version bump happens, a migration guide is published:
+
+- `v2-to-v3.mdx` — covers all breaking changes, before/after examples, and step-by-step migration instructions
+
+Migration guides are linked prominently from the new version's getting started page and from the release notes.
+
+### LTS Branches
+
+Long-term support branches are deferred to post-v2.0. When a major version bump happens, the previous major will get a maintenance branch (`v2.x`) for critical bugfixes. The LTS policy will be defined at that time.
+
+## Docs Deployment
+
+The documentation site is deployed via the `docs-deploy.yml` workflow, triggered on push to main. It builds the fumadocs Next.js application and deploys it to the hosting provider.
+
+The docs site structure under `website/content/` is organized into three tiers:
+
+- `content/user/` — getting started, configuration, module catalog, keybindings, themes, troubleshooting, FAQ
+- `content/module-authors/` — authoring guide, module.yml spec, lib API reference, testing guide
+- `content/contributors/` — architecture, platform adapters, module system, backend adapters, theme engine, testing strategy, CI/CD, distribution
+
+All architectural and design documents live as MDX pages in the fumadocs site. There are no orphan markdown files outside the website content structure.

--- a/website/content/contributors/meta.json
+++ b/website/content/contributors/meta.json
@@ -1,4 +1,13 @@
 {
   "title": "Contributors",
-  "pages": ["index"]
+  "pages": [
+    "architecture",
+    "platform-adapters",
+    "module-system",
+    "backend-adapters",
+    "theme-engine",
+    "testing-strategy",
+    "ci-cd",
+    "distribution"
+  ]
 }

--- a/website/content/contributors/module-system.mdx
+++ b/website/content/contributors/module-system.mdx
@@ -1,0 +1,344 @@
+---
+title: Module System
+description: Module contract, lifecycle, groups, layout hints, and capability-aware degradation.
+---
+
+Modules are the feature units of kall. Each module is a self-contained directory that provides a specific capability (power menu, clipboard manager, screenshot tool, etc.) through the shared lib infrastructure. This page covers the module contract, lifecycle, group system, layout hints, and how modules degrade gracefully across backends.
+
+## Module Structure
+
+Every module is a directory under `modules/` with a standard layout:
+
+```
+modules/power/
+├── module.yml       # metadata, deps, keybindings
+├── power.sh         # entry point (sources lib, focused logic)
+└── power.rasi       # optional module-specific theme override
+```
+
+The entry script (`power.sh`) sources lib files and calls lib functions exclusively. It never calls platform tools directly.
+
+## Module Contract: module.yml
+
+The `module.yml` file is the manifest that defines everything about a module. It is parsed by `yq` and validated against `schemas/module.schema.yml`.
+
+### Full Field Reference
+
+```yaml
+name: power
+description: Power menu — shutdown, reboot, lock, suspend, logout
+version: "1.0"
+author: shaiknoorullah
+category: system
+
+# Layout template — references a shared layout file from backends/<backend>/themes/
+# Options: clipboard (small dropdown), simple (single column),
+#          selector (icon grid), searchbar (fullscreen), launchpad (fullscreen grid)
+layout: clipboard
+
+platforms:
+  linux:
+    x11: true
+    wayland: true
+  macos: true
+
+requires:
+  lib:
+    - core
+    - platform
+    - menu
+    - notify
+  # Tools that lib/adapters need to fulfill this module's actions.
+  # Modules never call these directly — they call lib functions which
+  # delegate to adapters. Listed here so the installer knows what to install.
+  adapter_tools:
+    common:
+      - systemctl
+    wm:
+      x11: [i3lock, i3-msg]
+      wayland: [hyprlock, hyprctl]
+      darwin: [osascript]
+
+# Normalized keybinding — kall translates to WM-specific syntax
+keybinding:
+  mods: [mod, shift]     # mod | shift | ctrl | alt | super
+  key: e                 # single key (lowercase)
+
+config:
+  user_editable:
+    - key: confirm_destructive
+      description: Require confirmation for shutdown/reboot/logout
+      default: true
+```
+
+### Field Details
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | Yes | Unique identifier, must match directory name |
+| `description` | No | Human-readable one-liner |
+| `version` | No | Semver string |
+| `author` | No | Author name or handle |
+| `category` | No | One of: `system`, `productivity`, `developer`, `browser`, `notes`, `core` |
+| `layout` | No | Default layout template name |
+| `platforms` | No | Platform compatibility flags |
+| `requires.lib` | No | List of required kall lib modules |
+| `requires.adapter_tools` | No | Platform tools needed by lib adapters |
+| `keybinding` | No | Default keybinding in normalized form |
+| `config.user_editable` | No | Config keys the user can override |
+
+### Key Clarifications
+
+- **`layout`** specifies which layout template to use for this module's menu. The layout file lives under `backends/<backend>/themes/` and is generated per backend. It is not the same as a color theme.
+- **`requires.adapter_tools`** lists tools that lib adapters need, not tools the module calls directly. For example, the `power` module calls `lock_screen()` from `lib/platform.sh`, which delegates to the WM adapter, which calls `hyprlock` or `i3lock`. The module never touches these tools. They are listed so the installer knows what system packages to install.
+- **`platforms.linux.x11` and `platforms.linux.wayland`** must both be true or both be false. Modules cannot support only one Linux display server (enforced by invariant INV-MOD-05).
+
+### Schema Validation
+
+The schema at `schemas/module.schema.yml` validates the structure:
+
+```yaml
+properties:
+  name:
+    type: string
+    required: true
+  category:
+    type: string
+    enum: [system, productivity, developer, browser, notes, core]
+  platforms:
+    type: object
+    properties:
+      linux:
+        type: object
+        properties:
+          x11:
+            type: boolean
+          wayland:
+            type: boolean
+      macos:
+        type: boolean
+  requires:
+    type: object
+    properties:
+      lib:
+        type: array
+        items:
+          type: string
+      adapter_tools:
+        type: object
+  keybinding:
+    type: object
+    properties:
+      mods:
+        type: array
+        items:
+          type: string
+      key:
+        type: string
+```
+
+## Module Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Available: exists in source repo
+    Available --> Installing: kall add <name>
+    Installing --> CheckPlatform: check module.yml platforms
+    CheckPlatform --> Incompatible: platform not supported
+    CheckPlatform --> ResolveDeps: platform supported
+    Incompatible --> [*]: error + message
+    ResolveDeps --> InstallDeps: missing deps found
+    ResolveDeps --> Activate: all deps met
+    InstallDeps --> Activate: deps installed
+    Activate --> Installed: added to kall.yml
+    Installed --> Running: kall <module>
+    Running --> Installed: execution complete
+    Installed --> Removing: kall remove <name>
+    Removing --> Available: removed from kall.yml
+```
+
+### Management Commands
+
+```bash
+kall add emoji calculator systemd     # install modules + deps
+kall remove zen-workspaces            # remove from manifest
+kall list                             # installed modules
+kall list --available                 # all modules for this platform
+```
+
+`kall add` reads `module.yml`, checks platform compatibility, installs missing deps via the detected package manager, adds the module to `kall.yml`, and copies user-editable config files.
+
+## Module Groups
+
+Groups aggregate multiple modules into a single navigable menu. A group is a YAML file in `modules/groups/`:
+
+```yaml
+# modules/groups/system.yml
+
+name: system
+type: group
+description: System controls — power, display, bluetooth, services
+layout: tabs
+
+members:
+  - module: power
+    icon: "⏻"
+    label: Power
+  - module: display
+    icon: "󰍹"
+    label: Display
+  - module: bluetooth
+    icon: "󰂯"
+    label: Bluetooth
+  - module: systemd
+    icon: "󰒓"
+    label: Services
+
+keybinding:
+  mods: [mod, shift]
+  key: s
+```
+
+### Navigation Modes
+
+Groups declare a navigation layout that the backend adapter translates into its own rendering:
+
+| Layout | rofi | wofi/fuzzel | fzf |
+|---|---|---|---|
+| `tabs` | Native `-modi` tab bar | Dropdown selector at top | `--bind` ctrl-tab cycle + header |
+| `breadcrumbs` | `-mesg` header: `kall > system > power` | Header text | `--header` with back option |
+| `sections` | Pango markup section headers | Separator lines | ANSI colored headers |
+| `list` | Flat list, select opens module | Same | Same |
+
+### Group Navigation Flow
+
+```mermaid
+flowchart TD
+    User["kall system"] --> LoadGroup["Load modules/groups/system.yml"]
+    LoadGroup --> CheckMembers["Verify all member modules installed"]
+    CheckMembers --> RenderNav{"Navigation\nlayout?"}
+
+    RenderNav -->|tabs| Tabs["menu_launch with -modi\n(rofi) or tab cycling (fzf)"]
+    RenderNav -->|breadcrumbs| Bread["Show member list with\nback navigation"]
+    RenderNav -->|sections| Sections["All members in one list\nwith section headers"]
+    RenderNav -->|list| List["Flat list, select opens module"]
+
+    Tabs --> SelectModule["User selects a module"]
+    Bread --> SelectModule
+    Sections --> SelectModule
+    List --> SelectModule
+
+    SelectModule --> ExecModule["Execute selected module\n(same as kall <module> directly)"]
+```
+
+### Usage
+
+```bash
+kall system                      # opens the group
+kall system power                # jumps to power within group
+kall power                       # still works standalone
+```
+
+Users can create custom groups in `kall.yml`:
+
+```yaml
+custom_groups:
+  - name: favorites
+    layout: list
+    members: [power, clipboard, screenshot, websearch]
+```
+
+Shipped groups: `system`, `productivity`, `developer`, `browser`, `notes`.
+
+## Layout Hints
+
+Each module defines backend-agnostic layout preferences in `module.yml`. The backend adapter translates them into backend-specific rendering. Users can override any module's layout in `kall.yml`.
+
+```yaml
+layout: selector
+layout_hints:
+  columns: 4
+  icon_size: large           # small | medium | large
+  show_icons: true
+  show_preview: true
+  orientation: vertical      # horizontal | vertical
+  width: "80%"
+  lines: 8
+
+  # Backend-specific preview pipelines
+  preview:
+    fzf:
+      command: "chafa --size=40x20 {}"
+      position: right
+      size: "50%"
+    rofi:
+      icon_source: thumbnail
+```
+
+### fzf Preview Pipeline
+
+fzf's `--preview` flag supports piping to any tool, enabling rich previews:
+
+| Module | Preview command | Result |
+|---|---|---|
+| wallpaper | `chafa --size=40x20 {}` | Inline wallpaper thumbnail |
+| projects | `eza --tree --level=2 --icons --color=always {}` | Color file tree |
+| bookmarks | `curl -sL {url} \| bat --language=html` | Syntax-highlighted HTML |
+| clipboard | `bat --color=always --plain` | Full entry with syntax detect |
+| obsidian-search | `bat --language=markdown --color=always {}` | Rendered markdown |
+
+Preview degrades to plain text if a tool is missing.
+
+### User Overrides
+
+Users override layout hints per module in `kall.yml`:
+
+```yaml
+module_overrides:
+  wallpaper:
+    layout_hints:
+      columns: 6
+      icon_size: medium
+  projects:
+    layout_hints:
+      preview:
+        fzf:
+          command: "eza --tree --level=3 --icons --git-ignore --color=always {}"
+          size: "70%"
+```
+
+## Capability-Aware Degradation
+
+Modules query the menu backend for capabilities and degrade gracefully when a feature is not supported:
+
+```bash
+if menu_supports "blocks"; then
+  # live autocomplete via rofi-blocks
+  launch_with_blocks
+else
+  # simple text input
+  query=$(echo "" | menu_dmenu -p "Search")
+  open_search "$query"
+fi
+
+if menu_supports "markup"; then
+  label='<b><span color="#CBA6F7">Power</span></b>'
+else
+  label="Power"
+fi
+```
+
+The `menu_supports` function is provided by the loaded backend adapter. See the [backend adapters](/contributors/backend-adapters) page for the full capability matrix.
+
+A module must function correctly when any supported menu backend is active. Module behavior may degrade (fewer features) but must never crash or produce errors (invariant INV-MOD-06).
+
+## Module Invariants
+
+CI enforces these on every PR:
+
+- **INV-MOD-01:** Every directory under `modules/` (excluding `groups/`) must contain a `module.yml` and an entry script named `<module-name>.sh`
+- **INV-MOD-02:** Every module must have a corresponding `test_<module-name>.bats` file in `tests/`
+- **INV-MOD-03:** No module script may contain a direct invocation of any platform-specific tool. CI validates this by grepping for a forbidden tool list
+- **INV-MOD-04:** Every `module.yml` must validate against `schemas/module.schema.yml`
+- **INV-MOD-05:** Modules must not support only one Linux display server (both `x11` and `wayland` must match)
+- **INV-MOD-06:** A module must function correctly when any supported menu backend is active

--- a/website/content/contributors/platform-adapters.mdx
+++ b/website/content/contributors/platform-adapters.mdx
@@ -1,0 +1,320 @@
+---
+title: Platform Adapters
+description: WM and notification adapter interfaces, platform detection, and how to add a new adapter.
+---
+
+Platform adapters isolate kall from display-server-specific and OS-specific differences. Modules call unified lib functions; those functions delegate to the adapter loaded for the current environment. This page covers the WM adapter interface, notification adapter interface, platform detection, and how to write a new adapter.
+
+## WM Adapter Interface
+
+Every WM adapter in `lib/adapters/wm/` must implement five functions:
+
+| Function | Returns | Purpose |
+|---|---|---|
+| `wm_exit()` | exit code | Log out of the current WM session |
+| `wm_lock()` | exit code | Lock the screen |
+| `get_monitors()` | JSON array on stdout | List connected monitors with geometry |
+| `get_active_window()` | JSON object on stdout | Active window title, class, and PID |
+| `get_workspaces()` | JSON array on stdout | All workspaces with focus state |
+
+### Example: Hyprland Adapter
+
+From `lib/adapters/wm/hyprland.sh`:
+
+```bash
+wm_exit() {
+  hyprctl dispatch exit
+}
+
+wm_lock() {
+  if command -v hyprlock &>/dev/null; then
+    hyprlock
+  elif command -v swaylock &>/dev/null; then
+    swaylock
+  else
+    log_warn "wm_lock: no screen locker found"
+    return 1
+  fi
+}
+
+get_monitors() {
+  hyprctl monitors -j
+}
+
+get_active_window() {
+  hyprctl activewindow -j
+}
+
+get_workspaces() {
+  hyprctl workspaces -j
+}
+```
+
+### Example: Generic Fallback Adapter
+
+The `generic.sh` adapter implements the full interface with safe defaults. An unknown WM never prevents kall from running:
+
+```bash
+wm_exit() {
+  log_warn "wm_exit: no WM adapter configured; cannot exit"
+  return 1
+}
+
+wm_lock() {
+  if command -v hyprlock &>/dev/null; then
+    hyprlock
+  elif command -v swaylock &>/dev/null; then
+    swaylock
+  elif command -v i3lock &>/dev/null; then
+    i3lock
+  else
+    log_warn "wm_lock: no screen locker found (tried hyprlock, swaylock, i3lock)"
+    return 0
+  fi
+}
+
+get_monitors() {
+  echo '[{"name":"default","width":1920,"height":1080,"focused":true}]'
+}
+
+get_active_window() {
+  echo '{"title":"unknown","class":"unknown","pid":0}'
+}
+
+get_workspaces() {
+  echo '[{"id":1,"name":"1","focused":true}]'
+}
+```
+
+### Available WM Adapters
+
+| File | WM | Detection |
+|---|---|---|
+| `hyprland.sh` | Hyprland | `XDG_CURRENT_DESKTOP=Hyprland` |
+| `i3.sh` | i3 | `XDG_CURRENT_DESKTOP=i3` |
+| `sway.sh` | Sway | `XDG_CURRENT_DESKTOP=sway` |
+| `bspwm.sh` | bspwm | `XDG_CURRENT_DESKTOP=bspwm` |
+| `dwm.sh` | dwm | `XDG_CURRENT_DESKTOP=dwm` |
+| `macos.sh` | macOS | `uname` returns `Darwin` |
+| `generic.sh` | Any/fallback | Loaded when no specific adapter matches |
+
+## Notification Adapter Interface
+
+Every notify adapter in `lib/adapters/notify/` must implement one function:
+
+```bash
+_notify_send TITLE BODY [-i icon] [-t timeout] [-u urgency]
+```
+
+The `lib/notify.sh` file wraps this into convenience functions:
+
+```bash
+notify() {
+  _notify_send "$1" "${2:-}" -t 3000
+}
+
+notify_critical() {
+  _notify_send "$1" "${2:-}" -u critical
+}
+
+notify_with_icon() {
+  _notify_send "$1" "${2:-}" -i "${3:-}" -t 3000
+}
+```
+
+### Notification Adapter Selection
+
+The adapter is selected by `lib/platform.sh` at source time:
+
+```bash
+if [[ "$KALL_OS" == "darwin" ]]; then
+  source "$KALL_LIB_DIR/adapters/notify/macos.sh"
+elif command -v notify-send &>/dev/null; then
+  source "$KALL_LIB_DIR/adapters/notify/libnotify.sh"
+else
+  source "$KALL_LIB_DIR/adapters/notify/generic.sh"
+fi
+```
+
+| Adapter | Platform | Implementation |
+|---|---|---|
+| `libnotify.sh` | Linux with `notify-send` | Calls `notify-send` with `-i`, `-t`, `-u` flags |
+| `macos.sh` | macOS | Uses `osascript` to display notifications |
+| `generic.sh` | Any (fallback) | Prints `[notify:urgency] title: body` to stderr |
+
+## Platform Detection
+
+`lib/core.sh` detects three environment properties at source time:
+
+### OS Detection
+
+```bash
+_kall_detect_os() {
+  local kernel
+  kernel="$(uname)"
+  case "${kernel,,}" in
+    linux*)  echo "linux" ;;
+    darwin*) echo "darwin" ;;
+    *)       echo "linux" ;;
+  esac
+}
+```
+
+Exported as `KALL_OS`.
+
+### Session Type Detection
+
+```bash
+_kall_detect_session() {
+  if [[ "$KALL_OS" == "darwin" ]]; then
+    echo "darwin"
+    return
+  fi
+
+  case "${XDG_SESSION_TYPE:-}" in
+    wayland) echo "wayland" ;;
+    x11)     echo "x11" ;;
+    *)       echo "x11" ;;
+  esac
+}
+```
+
+Exported as `KALL_SESSION`. Used by `lib/platform.sh` to select the correct clipboard, screenshot, and wallpaper tools.
+
+### Window Manager Detection
+
+```bash
+_kall_detect_wm() {
+  if [[ "$KALL_OS" == "darwin" ]]; then
+    echo "macos"
+    return
+  fi
+
+  local desktop="${XDG_CURRENT_DESKTOP:-}"
+  case "${desktop,,}" in
+    hyprland) echo "hyprland" ;;
+    i3)       echo "i3" ;;
+    sway)     echo "sway" ;;
+    bspwm)    echo "bspwm" ;;
+    awesome)  echo "awesome" ;;
+    dwm)      echo "dwm" ;;
+    *)        echo "generic" ;;
+  esac
+}
+```
+
+Exported as `KALL_WM`. Used to load the correct WM adapter.
+
+## Platform Function Delegation
+
+`lib/platform.sh` provides unified functions that delegate based on `KALL_SESSION`:
+
+| Function | Wayland | X11 | macOS |
+|---|---|---|---|
+| `clipboard_copy()` | `wl-copy` | `xclip -selection clipboard` | `pbcopy` |
+| `clipboard_paste()` | `wl-paste` | `xclip -selection clipboard -o` | `pbpaste` |
+| `screenshot_full()` | `grim` | `maim` | `screencapture` |
+| `screenshot_area()` | `grim -g "$(slurp)"` | `maim -s` | `screencapture -s` |
+| `screenshot_window()` | `grim` + `hyprctl activewindow` | `maim -i $(xdotool)` | `screencapture -w` |
+| `set_wallpaper()` | `swww img` | `feh --bg-fill` | `osascript` |
+| `open_url()` | `xdg-open` | `xdg-open` | `open` |
+| `lock_screen()` | WM adapter `wm_lock()` | WM adapter `wm_lock()` | WM adapter `wm_lock()` |
+
+## How to Add a New WM Adapter
+
+1. **Create the adapter file** at `lib/adapters/wm/<wmname>.sh`
+
+2. **Add the source guard** to prevent double-sourcing:
+
+```bash
+#!/usr/bin/env bash
+# lib/adapters/wm/<wmname>.sh — <WM Name> adapter
+
+[[ -n "${_KALL_WM_WMNAME_LOADED:-}" ]] && return 0
+_KALL_WM_WMNAME_LOADED=1
+```
+
+3. **Implement all five interface functions.** Every function is required. If the WM does not support a particular action, return a non-zero exit code and log a warning:
+
+```bash
+wm_exit() {
+  # Your WM's logout command
+  wmname-msg exit
+}
+
+wm_lock() {
+  # Try known screen lockers in preference order
+  if command -v hyprlock &>/dev/null; then
+    hyprlock
+  else
+    log_warn "wm_lock: no compatible screen locker found"
+    return 1
+  fi
+}
+
+get_monitors() {
+  # Return JSON array of monitors
+  wmname-client monitors --json
+}
+
+get_active_window() {
+  # Return JSON object with title, class, pid
+  wmname-client active-window --json
+}
+
+get_workspaces() {
+  # Return JSON array of workspaces
+  wmname-client workspaces --json
+}
+```
+
+4. **Add WM detection** in `lib/core.sh`:
+
+```bash
+case "${desktop,,}" in
+  # ... existing entries ...
+  wmname) echo "wmname" ;;
+  *)      echo "generic" ;;
+esac
+```
+
+5. **Write tests** in `tests/test_wm_adapters.bats` covering all five functions with mocked WM commands.
+
+6. **All adapter functions must be idempotent.** Calling them multiple times with the same arguments must produce the same result.
+
+## How to Add a New Notification Adapter
+
+1. **Create the adapter file** at `lib/adapters/notify/<name>.sh`
+
+2. **Implement `_notify_send`** with the full parameter signature:
+
+```bash
+#!/usr/bin/env bash
+# lib/adapters/notify/<name>.sh
+
+[[ -n "${_KALL_NOTIFY_NAME_LOADED:-}" ]] && return 0
+_KALL_NOTIFY_NAME_LOADED=1
+
+_notify_send() {
+  local title="$1"
+  local body="$2"
+  shift 2
+
+  local icon="" timeout="" urgency=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -i) icon="$2"; shift 2 ;;
+      -t) timeout="$2"; shift 2 ;;
+      -u) urgency="$2"; shift 2 ;;
+      *)  shift ;;
+    esac
+  done
+
+  # Your notification implementation here
+}
+```
+
+3. **Add detection logic** in `lib/platform.sh` before the generic fallback.
+
+4. **Write tests** for the new adapter.

--- a/website/content/contributors/testing-strategy.mdx
+++ b/website/content/contributors/testing-strategy.mdx
@@ -1,0 +1,461 @@
+---
+title: Testing Strategy
+description: Five testing layers, BATS infrastructure, mock system, CI matrix, and writing tests for new modules.
+---
+
+kall uses a five-layer testing strategy to ensure correctness across platforms, display servers, and menu backends. All tests are written in BATS (Bash Automated Testing System) and run through a shared test infrastructure in `tests/test_helper/common.bash`. This page covers each testing layer, the mock system, the CI matrix, and how to write tests for new modules.
+
+## Five Testing Layers
+
+The testing strategy is organized into progressive layers, from fast isolated unit tests to full-system smoke tests:
+
+| Layer | Scope | What it validates | Speed |
+|---|---|---|---|
+| 1. Unit tests | Individual `lib/` functions | Platform detection, clipboard routing, theme loading, notification dispatch | Fast (ms) |
+| 2. Module tests | Single module end-to-end | Module entry script produces correct behavior given mock menu output | Fast (ms) |
+| 3. Integration tests | Cross-cutting concerns | YAML schema validation, module completeness, no forbidden tool calls, shellcheck/shfmt | Medium (seconds) |
+| 4. CI matrix | Platform combinations | All tests pass on Ubuntu 22.04, Ubuntu 24.04, macOS 14, across X11/Wayland/Darwin sessions | Slow (minutes) |
+| 5. Smoke tests | Full installation | Installer produces working system on fresh VM/container images | Slow (minutes) |
+
+### Layer 1: Unit Tests
+
+Every function in `lib/` is tested with platform mocks. Each test runs under multiple simulated environments by setting `XDG_SESSION_TYPE=x11`, `XDG_SESSION_TYPE=wayland`, and `OSTYPE=darwin`. This validates that platform-conditional logic branches correctly without needing real display servers.
+
+Example areas covered:
+- `lib/platform.sh` — clipboard operations route to the correct tool per platform
+- `lib/theme.sh` — palette loading, fallback behavior, wallbash extraction
+- `lib/notify.sh` — notification dispatch to libnotify vs macOS vs generic adapter
+- `lib/menu.sh` — backend loading, required function validation
+
+### Layer 2: Module Tests
+
+Every module must have a corresponding `test_<name>.bats` file in `tests/`. The CI `validate` job enforces this by scanning `modules/` directories and checking for matching test files. If a module exists without a test file, CI fails.
+
+Module tests use mock menu output (via `MENU_MOCK_OUTPUT`) to simulate user selections and verify the module calls the correct lib functions with the expected arguments. Tests never launch real rofi, wofi, or any GUI process.
+
+### Layer 3: Integration Tests
+
+Integration tests are structural validations that run without executing module code:
+
+- **YAML schema validation** — all `module.yml`, `kall.yml`, `group.yml`, and palette files are validated against versioned schemas in `schemas/`
+- **Module completeness** — every module directory contains `module.yml` + entry script + test file
+- **Forbidden tool calls** — `grep` scans all module scripts for direct invocations of platform-specific tools (`xclip`, `wl-copy`, `grim`, `maim`, `hyprctl`, `i3-msg`, `i3lock`, `swaymsg`, `pbcopy`, `pbpaste`, `screencapture`, `xdotool`, `xrandr`). Any match (excluding comments) fails the build. This enforces invariant INV-MOD-03.
+- **Shellcheck + shfmt** — all `.sh` files pass static analysis and formatting checks
+
+The `validate` job in `ci.yml` runs these checks:
+
+```yaml
+validate:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Check modules have tests
+      run: |
+        status=0
+        for dir in modules/*/; do
+          [ -d "$dir" ] || continue
+          name=$(basename "$dir")
+          [[ "$name" == "groups" ]] && continue
+          if [ ! -f "tests/test_${name}.bats" ]; then
+            echo "FAIL: modules/$name/ missing test file"
+            status=1
+          fi
+        done
+        exit $status
+    - name: Check no direct platform tool calls
+      run: |
+        forbidden="xclip\|wl-copy\|wl-paste\|grim\|maim\|hyprctl\|..."
+        if grep -rn "$forbidden" modules/ --include='*.sh' 2>/dev/null | grep -v '#'; then
+          echo "FAIL: modules contain direct platform tool calls"
+          exit 1
+        fi
+```
+
+### Layer 4: CI Matrix
+
+The test matrix runs all BATS tests across platform and session type combinations:
+
+| Runner | Session type | Tests run |
+|---|---|---|
+| `ubuntu-22.04` | `x11` | All lib + module tests |
+| `ubuntu-22.04` | `wayland` | All lib + module tests |
+| `ubuntu-24.04` | `x11` | All lib + module tests |
+| `ubuntu-24.04` | `wayland` | All lib + module tests |
+| `macos-14` | `darwin` | Lib tests + macOS-compatible module tests |
+
+The matrix is defined in `ci.yml` with exclusions for invalid combinations (macOS does not use X11 or Wayland session types):
+
+```yaml
+test:
+  runs-on: ${{ matrix.os }}
+  strategy:
+    matrix:
+      os: [ubuntu-22.04, ubuntu-24.04, macos-14]
+      session: [x11, wayland]
+      exclude:
+        - os: macos-14
+          session: x11
+        - os: macos-14
+          session: wayland
+      include:
+        - os: macos-14
+          session: darwin
+  steps:
+    - uses: actions/checkout@v4
+    - name: Run tests
+      env:
+        XDG_SESSION_TYPE: ${{ matrix.session }}
+      run: ./tests/run_tests.sh
+```
+
+### Layer 5: Smoke Tests
+
+Smoke tests validate the full installation flow on fresh images. They run `curl -fsSL kall.sh/install | bash` on clean Arch, Ubuntu, and macOS containers/VMs and verify:
+
+- `kall.yml` is created at `~/.config/kall/kall.yml`
+- `kall list` returns installed modules
+- `kall doctor` passes all checks
+
+## BATS Test Infrastructure
+
+All test files share a common setup and teardown through `tests/test_helper/common.bash`. This file provides:
+
+### Project Paths
+
+```bash
+export PROJECT_ROOT
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export LIB_DIR="$PROJECT_ROOT/lib"
+export MOCKS_DIR="$PROJECT_ROOT/tests/test_helper/mocks"
+```
+
+### Loading Helpers
+
+The infrastructure loads bats-support and bats-assert, which provide assertion functions like `assert_success`, `assert_failure`, `assert_output`, and `assert_line`:
+
+```bash
+load "$PROJECT_ROOT/tests/test_helper/bats-support/load"
+load "$PROJECT_ROOT/tests/test_helper/bats-assert/load"
+```
+
+### `common_setup`
+
+Called from `setup()` in each test file. Creates an isolated environment:
+
+```bash
+common_setup() {
+  # Create isolated temp directory
+  TEST_TEMP="$(mktemp -d)"
+  export TEST_TEMP
+
+  # Mock log file for tracking mock invocations
+  export MOCK_LOG="$TEST_TEMP/mock_calls.log"
+  touch "$MOCK_LOG"
+
+  # Menu mock output files
+  export MENU_MOCK_OUTPUT="$TEST_TEMP/menu_output"
+  export MENU_MULTI_OUTPUT="$TEST_TEMP/menu_multi_output"
+  export MENU_CALL_COUNT="$TEST_TEMP/menu_call_count"
+  echo "0" > "$MENU_CALL_COUNT"
+
+  # Override HOME to isolate tests from user config
+  export REAL_HOME="$HOME"
+  export HOME="$TEST_TEMP/home"
+  mkdir -p "$HOME"
+
+  # Set XDG dirs into temp
+  export XDG_CONFIG_HOME="$TEST_TEMP/config"
+  export XDG_DATA_HOME="$TEST_TEMP/data"
+  export XDG_CACHE_HOME="$TEST_TEMP/cache"
+  export XDG_STATE_HOME="$TEST_TEMP/state"
+  mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME"
+
+  # Inject mocks into PATH (prepend so they shadow real binaries)
+  export PATH="$MOCKS_DIR:$PATH"
+}
+```
+
+Key behaviors:
+- Every test gets its own `TEST_TEMP` directory, torn down after the test
+- `HOME` is redirected to prevent tests from reading or writing the developer's real config
+- XDG directories are isolated into temp so modules that use `XDG_CONFIG_HOME` operate in a sandbox
+- Mock binaries in `tests/test_helper/mocks/` are prepended to `PATH`, shadowing real platform tools
+
+### `common_teardown`
+
+Called from `teardown()` in each test file. Removes the temp directory:
+
+```bash
+common_teardown() {
+  if [[ -n "${TEST_TEMP:-}" && -d "$TEST_TEMP" ]]; then
+    rm -rf "$TEST_TEMP"
+  fi
+}
+```
+
+## Mock System
+
+Mocks are executable scripts in `tests/test_helper/mocks/` that simulate platform tools. Each mock logs its invocation to `MOCK_LOG` and returns controlled output.
+
+### Mock Logging
+
+Every mock writes its name and arguments to the shared log file:
+
+```bash
+#!/usr/bin/env bash
+MOCK_NAME="hyprctl"
+echo "$MOCK_NAME $*" >> "${MOCK_LOG:-/dev/null}"
+```
+
+This allows tests to assert which tools were called and with what arguments, without executing real binaries.
+
+### Available Mocks
+
+The project ships mocks for all platform-specific tools:
+
+| Category | Mocks |
+|---|---|
+| Clipboard | `xclip`, `wl-copy`, `wl-paste`, `pbcopy`, `pbpaste` |
+| Screenshot | `grim`, `slurp`, `maim`, `screencapture` |
+| Window manager | `hyprctl`, `i3-msg`, `swaymsg`, `xdotool`, `xrandr`, `bspc` |
+| Lock screen | `hyprlock`, `swaylock`, `slock`, `i3lock` |
+| Wallpaper | `swww`, `feh` |
+| Notification | `notify-send`, `osascript` |
+| Menu backends | `rofi` |
+| System | `open`, `xdg-open`, `playerctl`, `pkill`, `pmset` |
+| Data tools | `yq` |
+
+### `MENU_MOCK_OUTPUT`
+
+The primary mechanism for controlling menu selections. Tests write expected output to the `MENU_MOCK_OUTPUT` file, and the rofi mock reads and returns it:
+
+```bash
+@test "power module shows shutdown option" {
+  echo "Shutdown" > "$MENU_MOCK_OUTPUT"
+  run bash "$PROJECT_ROOT/modules/power/power.sh"
+  assert_success
+  assert_mock_called "systemctl"
+}
+```
+
+The `MENU_MOCK_OUTPUT` variable name is backend-agnostic (it replaced the legacy `ROFI_MOCK_OUTPUT` name from v1).
+
+### Multi-Call Menu Output
+
+For modules that show multiple sequential menus (e.g., a confirmation dialog after initial selection), use `set_menu_outputs`:
+
+```bash
+set_menu_outputs() {
+  : > "$MENU_MULTI_OUTPUT"
+  for output in "$@"; do
+    echo "$output" >> "$MENU_MULTI_OUTPUT"
+  done
+  echo "0" > "$MENU_CALL_COUNT"
+}
+```
+
+Each call to the mock menu reads the next line from `MENU_MULTI_OUTPUT`, incrementing the call counter. This simulates multi-step menu flows:
+
+```bash
+@test "power module confirms before shutdown" {
+  set_menu_outputs "Shutdown" "Yes"
+  run bash "$PROJECT_ROOT/modules/power/power.sh"
+  assert_success
+  assert_mock_called_with "systemctl" "poweroff"
+}
+```
+
+### Mock Assertion Helpers
+
+`common.bash` provides four assertion functions for verifying mock interactions:
+
+**`assert_mock_called <mock_name>`** — asserts the mock was called at least once:
+
+```bash
+assert_mock_called() {
+  local mock_name="$1"
+  if ! grep -q "^$mock_name " "$MOCK_LOG" 2>/dev/null; then
+    echo "Expected mock '$mock_name' to have been called, but it was not." >&2
+    return 1
+  fi
+}
+```
+
+**`assert_mock_not_called <mock_name>`** — asserts the mock was never called:
+
+```bash
+assert_mock_not_called() {
+  local mock_name="$1"
+  if grep -q "^$mock_name " "$MOCK_LOG" 2>/dev/null; then
+    echo "Expected mock '$mock_name' NOT to have been called, but it was." >&2
+    return 1
+  fi
+}
+```
+
+**`assert_mock_called_with <mock_name> <expected_args...>`** — asserts specific arguments:
+
+```bash
+assert_mock_called_with() {
+  local mock_name="$1"
+  shift
+  local expected_args="$*"
+  if ! grep -q "^$mock_name $expected_args" "$MOCK_LOG" 2>/dev/null; then
+    echo "Expected mock '$mock_name' to have been called with: $expected_args" >&2
+    return 1
+  fi
+}
+```
+
+**`get_mock_calls <mock_name>`** — returns all calls to a specific mock for custom assertions:
+
+```bash
+get_mock_calls() {
+  local mock_name="$1"
+  grep "^$mock_name " "$MOCK_LOG" 2>/dev/null || true
+}
+```
+
+## Writing Tests for a New Module
+
+When you create a new module, you must also create a test file. Here is a step-by-step guide using a hypothetical `calculator` module.
+
+### Step 1: Create the Test File
+
+Create `tests/test_calculator.bats`:
+
+```bash
+#!/usr/bin/env bats
+
+load test_helper/common
+
+setup() {
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+```
+
+### Step 2: Write Basic Execution Tests
+
+Test that the module runs and exits cleanly:
+
+```bash
+@test "calculator module loads without errors" {
+  echo "1+1" > "$MENU_MOCK_OUTPUT"
+  run bash "$PROJECT_ROOT/modules/calculator/calculator.sh"
+  assert_success
+}
+```
+
+### Step 3: Test Menu Interactions
+
+Use `MENU_MOCK_OUTPUT` to simulate user input and verify behavior:
+
+```bash
+@test "calculator sends expression to menu_calc" {
+  echo "42" > "$MENU_MOCK_OUTPUT"
+  run bash "$PROJECT_ROOT/modules/calculator/calculator.sh"
+  assert_success
+  assert_mock_called "rofi"
+}
+```
+
+### Step 4: Test Platform Branching
+
+Run the same test under different session types to verify cross-platform behavior:
+
+```bash
+@test "calculator works on x11" {
+  export XDG_SESSION_TYPE=x11
+  echo "2+2" > "$MENU_MOCK_OUTPUT"
+  run bash "$PROJECT_ROOT/modules/calculator/calculator.sh"
+  assert_success
+}
+
+@test "calculator works on wayland" {
+  export XDG_SESSION_TYPE=wayland
+  echo "2+2" > "$MENU_MOCK_OUTPUT"
+  run bash "$PROJECT_ROOT/modules/calculator/calculator.sh"
+  assert_success
+}
+```
+
+### Step 5: Test Error Handling
+
+Verify the module handles edge cases gracefully:
+
+```bash
+@test "calculator handles empty menu selection" {
+  echo "" > "$MENU_MOCK_OUTPUT"
+  run bash "$PROJECT_ROOT/modules/calculator/calculator.sh"
+  # Module should exit cleanly on empty selection (user cancelled)
+  assert_success
+}
+```
+
+### Step 6: Test Mock Assertions for Side Effects
+
+If the module calls platform tools, verify those calls:
+
+```bash
+@test "calculator copies result to clipboard" {
+  echo "42" > "$MENU_MOCK_OUTPUT"
+  export XDG_SESSION_TYPE=x11
+  run bash "$PROJECT_ROOT/modules/calculator/calculator.sh"
+  assert_mock_called "xclip"
+}
+
+@test "calculator uses wl-copy on wayland" {
+  echo "42" > "$MENU_MOCK_OUTPUT"
+  export XDG_SESSION_TYPE=wayland
+  run bash "$PROJECT_ROOT/modules/calculator/calculator.sh"
+  assert_mock_called "wl-copy"
+  assert_mock_not_called "xclip"
+}
+```
+
+## Running Tests
+
+### Full Suite
+
+Run all tests via the test runner script:
+
+```bash
+./tests/run_tests.sh
+```
+
+This discovers all `.bats` files in `tests/` and runs them through the BATS binary.
+
+### Single Test File
+
+Run tests for a specific module:
+
+```bash
+bats tests/test_power.bats
+```
+
+### With Verbose Output
+
+```bash
+bats --verbose-run tests/test_power.bats
+```
+
+### Under a Specific Session Type
+
+```bash
+XDG_SESSION_TYPE=wayland bats tests/test_clipboard.bats
+```
+
+## Test Naming Conventions
+
+Follow these conventions when naming test files and test cases:
+
+- Test files: `tests/test_<module-name>.bats`
+- Test names should describe the expected behavior, not the implementation:
+  - Good: `"clipboard copies text on x11"`
+  - Bad: `"clipboard calls xclip with -selection clipboard"`
+- Group related tests together. Put platform-specific tests after general tests.
+- Always test both success and failure paths.

--- a/website/content/contributors/theme-engine.mdx
+++ b/website/content/contributors/theme-engine.mdx
@@ -1,0 +1,383 @@
+---
+title: Theme Engine
+description: Palette format, static and dynamic theme loading, wallbash color extraction, and theme generation across backends.
+---
+
+The theme engine (`lib/theme.sh`) manages color palettes across the entire kall system. It loads colors from YAML palette files, exports standardized `KALL_COLOR_*` environment variables, and optionally extracts colors from the current wallpaper using ImageMagick. This page covers the palette format, both loading modes, the cross-backend theme generation pipeline, and how to add a custom palette.
+
+## Palette YAML Format
+
+Every palette lives in `themes/palettes/` as a YAML file. The format defines eight canonical color slots that map to semantic roles in the UI. Here is the structure using `catppuccin-mocha.yml` as a reference:
+
+```yaml
+# themes/palettes/catppuccin-mocha.yml
+name: Catppuccin Mocha
+author: catppuccin
+variant: dark
+
+colors:
+  main_bg: "#1e1e2e"     # Primary background
+  main_fg: "#cdd6f4"     # Primary foreground / text
+  main_br: "#89b4fa"     # Border / accent color
+  main_ex: "#f5c2e7"     # Extra accent (highlights, badges)
+  select_bg: "#313244"   # Selected item background
+  select_fg: "#cdd6f4"   # Selected item foreground
+  urgent_bg: "#f38ba8"   # Urgent / error background
+  urgent_fg: "#1e1e2e"   # Urgent / error foreground
+```
+
+All eight color keys are required. A palette that omits any key is invalid and will fail schema validation against `schemas/palette.schema.yml`. The invariant INV-THM-01 enforces this: no partial palettes are allowed.
+
+The shipped palettes are:
+
+| Palette | File |
+|---|---|
+| Catppuccin Mocha | `catppuccin-mocha.yml` |
+| Dracula | `dracula.yml` |
+| Nord | `nord.yml` |
+| Gruvbox | `gruvbox.yml` |
+| Tokyo Night | `tokyo-night.yml` |
+| Rose Pine | `rose-pine.yml` |
+
+## Static Palette Loading
+
+Static loading is the default mode. When `lib/theme.sh` is sourced, it calls `load_theme` to read the active palette and export color variables.
+
+### `load_theme` Function
+
+```bash
+load_theme() {
+  local palette_name="${1:-${KALL_THEME:-catppuccin-mocha}}"
+  local palette_file="$KALL_PALETTES_DIR/${palette_name}.yml"
+
+  # Fallback to catppuccin-mocha if palette not found
+  if [[ ! -f "$palette_file" ]]; then
+    log_warn "theme.sh: palette '$palette_name' not found, falling back to catppuccin-mocha"
+    palette_name="catppuccin-mocha"
+    palette_file="$KALL_PALETTES_DIR/${palette_name}.yml"
+  fi
+
+  if [[ ! -f "$palette_file" ]]; then
+    log_error "theme.sh: fallback palette catppuccin-mocha not found at $palette_file"
+    return 1
+  fi
+
+  if ! command -v yq &>/dev/null; then
+    log_error "theme.sh: yq not found, cannot load palette"
+    return 1
+  fi
+
+  # Read each color via yq and export
+  KALL_COLOR_MAIN_BG="$(yq '.colors.main_bg' "$palette_file" 2>/dev/null)"
+  KALL_COLOR_MAIN_FG="$(yq '.colors.main_fg' "$palette_file" 2>/dev/null)"
+  KALL_COLOR_MAIN_BR="$(yq '.colors.main_br' "$palette_file" 2>/dev/null)"
+  KALL_COLOR_MAIN_EX="$(yq '.colors.main_ex' "$palette_file" 2>/dev/null)"
+  KALL_COLOR_SELECT_BG="$(yq '.colors.select_bg' "$palette_file" 2>/dev/null)"
+  KALL_COLOR_SELECT_FG="$(yq '.colors.select_fg' "$palette_file" 2>/dev/null)"
+  KALL_COLOR_URGENT_BG="$(yq '.colors.urgent_bg' "$palette_file" 2>/dev/null)"
+  KALL_COLOR_URGENT_FG="$(yq '.colors.urgent_fg' "$palette_file" 2>/dev/null)"
+
+  export KALL_COLOR_MAIN_BG KALL_COLOR_MAIN_FG KALL_COLOR_MAIN_BR KALL_COLOR_MAIN_EX
+  export KALL_COLOR_SELECT_BG KALL_COLOR_SELECT_FG
+  export KALL_COLOR_URGENT_BG KALL_COLOR_URGENT_FG
+}
+```
+
+The resolution order is:
+
+1. Explicit argument passed to `load_theme` (e.g., `load_theme dracula`)
+2. The `KALL_THEME` environment variable (set by `core.sh` from `kall.yml`)
+3. Hardcoded fallback: `catppuccin-mocha`
+
+If the requested palette file does not exist, the function logs a warning and falls back to `catppuccin-mocha`. If even the fallback is missing, it returns exit code 1 and logs an error. The `yq` binary is required for palette parsing; if absent, loading fails with an error.
+
+### Auto-Load Behavior
+
+When `lib/theme.sh` is sourced, it automatically loads a theme at the bottom of the file:
+
+```bash
+if [[ "${KALL_DYNAMIC_THEME:-false}" == "true" ]]; then
+  # Try wallbash first, fall back to static palette
+  if ! generate_wallbash "${KALL_WALLPAPER:-}"; then
+    load_theme
+  fi
+else
+  load_theme
+fi
+```
+
+This means every module gets color variables populated before it runs. No module needs to call `load_theme` manually.
+
+## Dynamic Wallbash
+
+Wallbash is the opt-in dynamic theming mode. Instead of reading from a curated palette file, it extracts dominant colors from the user's current wallpaper using ImageMagick and maps them to `KALL_COLOR_*` variables.
+
+### Enabling Wallbash
+
+Users enable wallbash via:
+
+```bash
+kall theme wallbash on
+```
+
+This sets `dynamic_theme: true` in `kall.yml`, which causes `KALL_DYNAMIC_THEME=true` to be set when `core.sh` loads config. The theme engine then tries `generate_wallbash` before falling back to `load_theme`.
+
+### `generate_wallbash` Function
+
+The function takes a wallpaper file path and performs color extraction:
+
+```bash
+generate_wallbash() {
+  local wallpaper="$1"
+
+  # Validate wallpaper exists
+  if [[ ! -f "$wallpaper" ]]; then
+    log_warn "theme.sh: wallpaper not found: $wallpaper"
+    return 1
+  fi
+
+  # Require ImageMagick
+  if ! command -v convert &>/dev/null; then
+    log_warn "theme.sh: ImageMagick (convert) not found, cannot generate wallbash"
+    return 1
+  fi
+
+  # Extract 8 dominant colors using color quantization
+  local colors
+  colors="$(convert "$wallpaper" -resize 100x100! -colors 8 -unique-colors txt:- 2>/dev/null \
+    | grep -oE '#[0-9A-Fa-f]{6}' | head -8)"
+  ...
+}
+```
+
+The extraction pipeline works as follows:
+
+1. **Resize** the wallpaper to 100x100 pixels (forced aspect ratio) to speed up processing.
+2. **Quantize** to 8 colors using ImageMagick's built-in color reduction algorithm.
+3. **Extract unique colors** into text format and parse hex values.
+4. **Sort by luminance** to assign colors to semantic roles (darkest colors become backgrounds, lightest become foregrounds).
+
+### Luminance Sorting
+
+After extraction, colors are sorted by relative luminance using the formula `R * 299 + G * 587 + B * 114` (the BT.601 luma coefficients). This produces a consistent mapping:
+
+| Sort position | Maps to | Semantic role |
+|---|---|---|
+| 1 (darkest) | `KALL_COLOR_MAIN_BG` | Primary background |
+| 2 | `KALL_COLOR_SELECT_BG` | Selected item background |
+| 4 | `KALL_COLOR_URGENT_BG` | Urgent background |
+| 5 | `KALL_COLOR_MAIN_EX` | Extra accent |
+| 6 | `KALL_COLOR_MAIN_BR` | Border accent |
+| 7 | `KALL_COLOR_SELECT_FG` | Selected item foreground |
+| 8 (lightest) | `KALL_COLOR_MAIN_FG`, `KALL_COLOR_URGENT_FG` | Primary and urgent foreground |
+
+### Fallback Behavior
+
+The wallbash function returns exit code 1 in three cases:
+
+- The wallpaper file does not exist
+- ImageMagick (`convert`) is not installed
+- Color extraction produced fewer than 8 colors
+
+In all cases, the auto-load block catches the failure and falls back to `load_theme`, loading the static palette. This satisfies invariant INV-THM-03: dynamic theme generation always falls back gracefully.
+
+## Theme Generation Across Backends
+
+Palette files are backend-agnostic YAML. Each menu backend needs colors in its own format (rofi uses `.rasi`, wofi uses `.css`, fzf uses shell environment variables). The `backends/generate-themes.sh` script bridges this gap.
+
+### Pipeline
+
+```
+themes/palettes/*.yml
+        |
+        v
+backends/generate-themes.sh
+        |
+        +---> backends/rofi/themes/*.rasi
+        +---> backends/wofi/themes/*.css
+        +---> backends/tofi/themes/*.ini
+        +---> backends/fuzzel/themes/*.ini
+        +---> backends/dmenu/themes/*.sh
+        +---> backends/fzf/themes/*.sh
+```
+
+The script iterates over every palette in `themes/palettes/`, reads the eight canonical color values, and writes a theme file in each backend's native format. This design means adding a new palette requires zero changes to any backend — you drop a `.yml` file in `themes/palettes/` and run `generate-themes.sh`.
+
+### Backend Theme Formats
+
+Each backend receives colors in its native syntax:
+
+**Rofi** (`.rasi`):
+```rasi
+* {
+    kall-main-bg: #1e1e2e;
+    kall-main-fg: #cdd6f4;
+    kall-main-br: #89b4fa;
+    kall-main-ex: #f5c2e7;
+    kall-select-bg: #313244;
+    kall-select-fg: #cdd6f4;
+    kall-urgent-bg: #f38ba8;
+    kall-urgent-fg: #1e1e2e;
+}
+```
+
+**Wofi** (`.css`):
+```css
+@define-color kall-main-bg #1e1e2e;
+@define-color kall-main-fg #cdd6f4;
+/* ... */
+```
+
+**fzf** (`.sh`):
+```bash
+export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS \
+  --color=bg+:#313244,bg:#1e1e2e,fg:#cdd6f4,fg+:#cdd6f4 \
+  --color=hl:#f5c2e7,hl+:#f5c2e7,info:#89b4fa,marker:#f5c2e7 \
+  --color=prompt:#89b4fa,spinner:#f5c2e7,pointer:#f5c2e7,header:#f38ba8"
+```
+
+**dmenu** (`.sh`):
+```bash
+DMENU_COLORS="-nb '#1e1e2e' -nf '#cdd6f4' -sb '#313244' -sf '#cdd6f4'"
+```
+
+**tofi / fuzzel** (`.ini`):
+```ini
+[colors]
+background = #1e1e2e
+foreground = #cdd6f4
+selection-background = #313244
+selection-foreground = #cdd6f4
+border = #89b4fa
+```
+
+Invariant INV-THM-02 requires that `generate-themes.sh` produces valid output for every backend from any valid palette. A new palette file must never require changes to any backend's theme generation logic.
+
+## Color Variable Reference
+
+After theme loading (static or wallbash), these environment variables are exported and available to all lib functions and backend adapters:
+
+| Variable | Palette key | Semantic role |
+|---|---|---|
+| `KALL_COLOR_MAIN_BG` | `colors.main_bg` | Primary background |
+| `KALL_COLOR_MAIN_FG` | `colors.main_fg` | Primary foreground / text |
+| `KALL_COLOR_MAIN_BR` | `colors.main_br` | Border and accent color |
+| `KALL_COLOR_MAIN_EX` | `colors.main_ex` | Extra accent (highlights, badges) |
+| `KALL_COLOR_SELECT_BG` | `colors.select_bg` | Selected item background |
+| `KALL_COLOR_SELECT_FG` | `colors.select_fg` | Selected item foreground |
+| `KALL_COLOR_URGENT_BG` | `colors.urgent_bg` | Urgent / error background |
+| `KALL_COLOR_URGENT_FG` | `colors.urgent_fg` | Urgent / error foreground |
+
+Backend adapters read these variables when constructing theme arguments. Modules never read color variables directly — they declare layout hints and the backend handles all visual rendering.
+
+## Listing Available Palettes
+
+The `list_palettes` function scans `themes/palettes/` and returns bare palette names (without path or extension):
+
+```bash
+list_palettes() {
+  local f
+  for f in "$KALL_PALETTES_DIR"/*.yml; do
+    [[ -f "$f" ]] || continue
+    basename "$f" .yml
+  done
+}
+```
+
+The CLI exposes this via `kall theme list`.
+
+## Adding a Custom Palette
+
+To add a new palette to kall:
+
+### Step 1: Create the Palette File
+
+Create a YAML file in `themes/palettes/` with your palette name:
+
+```bash
+touch themes/palettes/my-custom-theme.yml
+```
+
+### Step 2: Define All Eight Colors
+
+Populate the file with the required structure. Every key under `colors` is mandatory:
+
+```yaml
+name: My Custom Theme
+author: your-name
+variant: dark  # or "light"
+
+colors:
+  main_bg: "#1a1b26"
+  main_fg: "#c0caf5"
+  main_br: "#7aa2f7"
+  main_ex: "#bb9af7"
+  select_bg: "#283457"
+  select_fg: "#c0caf5"
+  urgent_bg: "#f7768e"
+  urgent_fg: "#1a1b26"
+```
+
+### Step 3: Validate Against the Schema
+
+Run schema validation to ensure all required keys are present:
+
+```bash
+kall doctor
+```
+
+The doctor command validates palette files against `schemas/palette.schema.yml`.
+
+### Step 4: Generate Backend Themes
+
+Run the theme generation script to produce backend-specific theme files:
+
+```bash
+./backends/generate-themes.sh
+```
+
+This reads your new palette and creates theme files in every backend's `themes/` directory.
+
+### Step 5: Test the Palette
+
+Activate your palette and verify it renders correctly:
+
+```bash
+kall theme set my-custom-theme
+kall power  # or any module — check that colors apply
+```
+
+### Step 6: Commit
+
+Follow the commit convention:
+
+```bash
+git add themes/palettes/my-custom-theme.yml
+git commit -m "feat(theme/my-custom-theme): add custom dark palette"
+```
+
+## Theme Flow Diagram
+
+The full flow from user config to rendered menu:
+
+```mermaid
+flowchart TD
+    Start["lib/theme.sh sourced"] --> CheckWallbash{"KALL_DYNAMIC_THEME\n== true?"}
+    CheckWallbash -->|no| LoadStatic["load_theme()\nRead themes/palettes/\$KALL_THEME.yml"]
+    CheckWallbash -->|yes| CheckIM{"ImageMagick\navailable?"}
+    CheckIM -->|no| LoadStatic
+    CheckIM -->|yes| CheckWall{"KALL_WALLPAPER\nfile exists?"}
+    CheckWall -->|no| LoadStatic
+    CheckWall -->|yes| Extract["generate_wallbash()\nExtract 8 dominant colors"]
+    Extract --> SortLum["Sort by luminance\nMap to KALL_COLOR_* vars"]
+    SortLum --> ExportVars["Export KALL_COLOR_* variables"]
+    LoadStatic --> ExportVars
+    ExportVars --> Backend["Backend adapter reads\nKALL_COLOR_* vars"]
+    Backend --> Render["Menu rendered with\npalette colors applied"]
+```
+
+## Relevant Invariants
+
+- **INV-THM-01:** Every palette in `themes/palettes/` must define the complete set of required color variables. No partial palettes.
+- **INV-THM-02:** `backends/generate-themes.sh` must produce valid theme files for every backend from any valid palette. A new palette must not require changes to any backend.
+- **INV-THM-03:** Dynamic wallbash theme generation must fall back to the active static palette if ImageMagick is not installed or wallpaper extraction fails.


### PR DESCRIPTION
Closes #66

## Summary
8 contributor documentation pages ported from the design spec.

## Pages
- architecture.mdx (286 lines)
- platform-adapters.mdx (320 lines)
- module-system.mdx (344 lines)
- backend-adapters.mdx (274 lines)
- theme-engine.mdx (383 lines) - new
- testing-strategy.mdx (461 lines) - new
- ci-cd.mdx (432 lines) - new
- distribution.mdx (201 lines) - new