### PR TITLE
feat(docs/landing): landing page, user docs, and module author docs

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,26 +1,26 @@
-import Link from 'next/link';
+import { Hero } from '@/components/landing/hero';
+import { Demo } from '@/components/landing/demo';
+import { Features } from '@/components/landing/features';
+import { Modules } from '@/components/landing/modules';
+import { Themes } from '@/components/landing/themes';
+import { SocialProof } from '@/components/landing/social-proof';
+import { GettingStarted } from '@/components/landing/getting-started';
+import { Footer } from '@/components/landing/footer';
 
 export default function HomePage() {
   return (
-    <main className="flex flex-1 flex-col items-center justify-center text-center">
-      <h1 className="mb-4 text-4xl font-bold">kall</h1>
-      <p className="mb-8 text-fd-muted-foreground">
-        Documentation site coming soon.
-      </p>
-      <div className="flex gap-4">
-        <Link
-          href="/docs"
-          className="rounded-lg bg-fd-primary px-6 py-3 text-sm font-medium text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
-        >
-          Read the Docs
-        </Link>
-        <Link
-          href="/showcase"
-          className="rounded-lg border border-fd-border px-6 py-3 text-sm font-medium transition-colors hover:bg-fd-accent"
-        >
-          Showcase
-        </Link>
-      </div>
+    <main className="min-h-screen bg-[#1E1E2E] text-[#CDD6F4]">
+      <Hero />
+      <Demo />
+      <Features />
+      <div className="mx-auto max-w-5xl border-t border-[#313244]" />
+      <Modules />
+      <div className="mx-auto max-w-5xl border-t border-[#313244]" />
+      <Themes />
+      <SocialProof />
+      <div className="mx-auto max-w-5xl border-t border-[#313244]" />
+      <GettingStarted />
+      <Footer />
     </main>
   );
 }

--- a/website/components/landing/demo.tsx
+++ b/website/components/landing/demo.tsx
@@ -2,32 +2,18 @@ export function Demo() {
   return (
     <section className="px-6 py-20">
       <div className="mx-auto max-w-4xl">
-        <h2 className="mb-4 text-center text-sm font-semibold uppercase tracking-widest text-[#CBA6F7]">
-          See it in action
-        </h2>
-
-        {/* Terminal window */}
+        <h2 className="mb-4 text-center text-sm font-semibold uppercase tracking-widest text-[#CBA6F7]">See it in action</h2>
         <div className="overflow-hidden rounded-xl border border-[#45475A] bg-[#181825] shadow-2xl shadow-black/30">
-          {/* Title bar */}
           <div className="flex items-center gap-2 border-b border-[#313244] px-4 py-3">
             <div className="h-3 w-3 rounded-full bg-[#F38BA8]" />
             <div className="h-3 w-3 rounded-full bg-[#F9E2AF]" />
             <div className="h-3 w-3 rounded-full bg-[#A6E3A1]" />
             <span className="ml-3 text-xs text-[#6C7086]">kall — bash</span>
           </div>
-
-          {/* Terminal body / placeholder */}
           <div className="flex min-h-[350px] flex-col items-center justify-center p-8 sm:min-h-[420px]">
-            <div className="mb-6 text-5xl opacity-30">
-              <span className="font-mono text-[#CBA6F7]">&gt;_</span>
-            </div>
-            <p className="mb-2 text-lg font-medium text-[#BAC2DE]">
-              Demo coming soon
-            </p>
-            <p className="max-w-sm text-center text-sm text-[#6C7086]">
-              A full walkthrough of kall in action — switching backends,
-              launching modules, and wallbash theming on the fly.
-            </p>
+            <div className="mb-6 text-5xl opacity-30"><span className="font-mono text-[#CBA6F7]">&gt;_</span></div>
+            <p className="mb-2 text-lg font-medium text-[#BAC2DE]">Demo coming soon</p>
+            <p className="max-w-sm text-center text-sm text-[#6C7086]">A full walkthrough of kall in action — switching backends, launching modules, and wallbash theming on the fly.</p>
           </div>
         </div>
       </div>

--- a/website/components/landing/features.tsx
+++ b/website/components/landing/features.tsx
@@ -1,62 +1,24 @@
 const features = [
-  {
-    icon: '\u29C9',
-    title: 'Modular',
-    description: 'Install only what you need. Skip the rest.',
-  },
-  {
-    icon: '\u21C4',
-    title: 'Any Backend',
-    description: 'Swap rofi for wofi for fzf. Nothing breaks.',
-  },
-  {
-    icon: '\u2316',
-    title: 'Cross-Platform',
-    description: 'X11, Wayland, and macOS. One config.',
-  },
-  {
-    icon: '\u25D0',
-    title: 'Dynamic Themes',
-    description: 'Colors extracted from your wallpaper. Automatically.',
-  },
-  {
-    icon: '\u0023',
-    title: 'Pure Bash',
-    description: 'Zero Python. Zero runtime deps. Just bash.',
-  },
-  {
-    icon: '\u002B',
-    title: 'Extensible',
-    description: 'Write a module in 20 lines. Share it with everyone.',
-  },
+  { icon: '\u29C9', title: 'Modular', description: 'Install only what you need. Skip the rest.' },
+  { icon: '\u21C4', title: 'Any Backend', description: 'Swap rofi for wofi for fzf. Nothing breaks.' },
+  { icon: '\u2316', title: 'Cross-Platform', description: 'X11, Wayland, and macOS. One config.' },
+  { icon: '\u25D0', title: 'Dynamic Themes', description: 'Colors extracted from your wallpaper. Automatically.' },
+  { icon: '\u0023', title: 'Pure Bash', description: 'Zero Python. Zero runtime deps. Just bash.' },
+  { icon: '\u002B', title: 'Extensible', description: 'Write a module in 20 lines. Share it with everyone.' },
 ];
 
 export function Features() {
   return (
     <section className="px-6 py-24">
       <div className="mx-auto max-w-5xl">
-        <h2 className="mb-4 text-center text-sm font-semibold uppercase tracking-widest text-[#CBA6F7]">
-          Why kall
-        </h2>
-        <p className="mx-auto mb-16 max-w-lg text-center text-lg text-[#BAC2DE]">
-          Everything you cobbled together from 10 repos, but it actually works together.
-        </p>
-
+        <h2 className="mb-4 text-center text-sm font-semibold uppercase tracking-widest text-[#CBA6F7]">Why kall</h2>
+        <p className="mx-auto mb-16 max-w-lg text-center text-lg text-[#BAC2DE]">Everything you cobbled together from 10 repos, but it actually works together.</p>
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {features.map((feature) => (
-            <div
-              key={feature.title}
-              className="group rounded-xl border border-[#313244] bg-[#181825]/60 p-6 transition-all hover:border-[#45475A] hover:bg-[#181825]"
-            >
-              <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-[#313244] text-xl text-[#CBA6F7] transition-colors group-hover:bg-[#CBA6F7]/15">
-                {feature.icon}
-              </div>
-              <h3 className="mb-2 text-lg font-semibold text-[#CDD6F4]">
-                {feature.title}
-              </h3>
-              <p className="text-sm leading-relaxed text-[#A6ADC8]">
-                {feature.description}
-              </p>
+            <div key={feature.title} className="group rounded-xl border border-[#313244] bg-[#181825]/60 p-6 transition-all hover:border-[#45475A] hover:bg-[#181825]">
+              <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-[#313244] text-xl text-[#CBA6F7] transition-colors group-hover:bg-[#CBA6F7]/15">{feature.icon}</div>
+              <h3 className="mb-2 text-lg font-semibold text-[#CDD6F4]">{feature.title}</h3>
+              <p className="text-sm leading-relaxed text-[#A6ADC8]">{feature.description}</p>
             </div>
           ))}
         </div>

--- a/website/components/landing/footer.tsx
+++ b/website/components/landing/footer.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+
+const links = [
+  { label: 'Docs', href: '/docs' },
+  { label: 'GitHub', href: 'https://github.com/shaiknoorullah/kall', external: true },
+  { label: 'Showcase', href: '/showcase' },
+  { label: 'Contributing', href: 'https://github.com/shaiknoorullah/kall/blob/main/CONTRIBUTING.md', external: true },
+];
+
+export function Footer() {
+  return (
+    <footer className="border-t border-[#313244] px-6 py-12">
+      <div className="mx-auto flex max-w-4xl flex-col items-center gap-6">
+        {/* Links */}
+        <nav className="flex flex-wrap justify-center gap-6">
+          {links.map((link) =>
+            link.external ? (
+              <a key={link.label} href={link.href} target="_blank" rel="noopener noreferrer" className="text-sm text-[#6C7086] transition-colors hover:text-[#CDD6F4]">
+                {link.label}
+              </a>
+            ) : (
+              <Link key={link.label} href={link.href} className="text-sm text-[#6C7086] transition-colors hover:text-[#CDD6F4]">
+                {link.label}
+              </Link>
+            )
+          )}
+        </nav>
+
+        {/* License and author */}
+        <div className="flex flex-col items-center gap-1 text-xs text-[#6C7086]">
+          <span>MIT License</span>
+          <span>
+            Built by{' '}
+            <a href="https://github.com/shaiknoorullah" target="_blank" rel="noopener noreferrer" className="text-[#BAC2DE] transition-colors hover:text-[#CDD6F4]">
+              @shaiknoorullah
+            </a>
+          </span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/website/components/landing/getting-started.tsx
+++ b/website/components/landing/getting-started.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+const steps = [
+  { number: '1', title: 'Install', description: 'One command. No package managers, no make, no sudo.' },
+  { number: '2', title: 'Pick modules', description: 'Enable only the modules you actually use.' },
+  { number: '3', title: 'Add keybindings', description: 'Bind kall to Super+Space and forget about it.' },
+];
+
+export function GettingStarted() {
+  const [copied, setCopied] = useState(false);
+  const installCmd = 'curl -fsSL kall.sh/install | bash';
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(installCmd);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      const textarea = document.createElement('textarea');
+      textarea.value = installCmd;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <section className="px-6 py-24">
+      <div className="mx-auto max-w-3xl">
+        <h2 className="mb-4 text-center text-sm font-semibold uppercase tracking-widest text-[#CBA6F7]">
+          Get started in 30 seconds
+        </h2>
+        <p className="mx-auto mb-14 max-w-md text-center text-lg text-[#BAC2DE]">
+          Three steps. No gotchas.
+        </p>
+
+        {/* Steps */}
+        <div className="mb-14 grid gap-6 sm:grid-cols-3">
+          {steps.map((step) => (
+            <div key={step.number} className="text-center">
+              <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full border border-[#CBA6F7]/30 bg-[#CBA6F7]/10 text-sm font-bold text-[#CBA6F7]">
+                {step.number}
+              </div>
+              <h3 className="mb-2 text-lg font-semibold text-[#CDD6F4]">{step.title}</h3>
+              <p className="text-sm text-[#A6ADC8]">{step.description}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Install command */}
+        <div className="mx-auto mb-10 max-w-lg">
+          <div className="group relative flex items-center rounded-lg border border-[#45475A] bg-[#181825] font-mono text-sm transition-colors hover:border-[#585B70]">
+            <span className="select-none px-4 text-[#6C7086]">$</span>
+            <code className="flex-1 py-3.5 pr-2 text-[#A6E3A1]">{installCmd}</code>
+            <button
+              onClick={handleCopy}
+              className="mr-2 rounded-md px-3 py-1.5 text-xs text-[#6C7086] transition-all hover:bg-[#313244] hover:text-[#CDD6F4]"
+              aria-label="Copy install command"
+            >
+              {copied ? (
+                <span className="text-[#A6E3A1]">copied!</span>
+              ) : (
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* CTA */}
+        <div className="text-center">
+          <Link
+            href="/docs/user/getting-started"
+            className="inline-block rounded-lg bg-[#CBA6F7] px-8 py-3.5 text-sm font-semibold text-[#1E1E2E] transition-all hover:bg-[#CBA6F7]/85 hover:shadow-lg hover:shadow-[#CBA6F7]/20"
+          >
+            Read the full guide
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/components/landing/hero.tsx
+++ b/website/components/landing/hero.tsx
@@ -26,29 +26,22 @@ export function Hero() {
 
   return (
     <section className="relative flex min-h-[90vh] flex-col items-center justify-center overflow-hidden px-6 py-24">
-      {/* Background glow effects */}
       <div className="pointer-events-none absolute inset-0">
         <div className="absolute left-1/2 top-1/4 h-[500px] w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#CBA6F7]/8 blur-[120px]" />
         <div className="absolute right-1/4 top-1/2 h-[300px] w-[300px] rounded-full bg-[#89B4FA]/6 blur-[100px]" />
         <div className="absolute bottom-1/4 left-1/3 h-[250px] w-[250px] rounded-full bg-[#F5C2E7]/5 blur-[90px]" />
       </div>
-
       <div className="relative z-10 flex max-w-3xl flex-col items-center text-center">
-        {/* Project name with animated gradient */}
         <h1 className="mb-6 text-8xl font-black tracking-tighter sm:text-9xl">
           <span className="hero-glow bg-gradient-to-r from-[#CBA6F7] via-[#89B4FA] to-[#F5C2E7] bg-clip-text text-transparent">
             kall
           </span>
         </h1>
-
-        {/* Tagline */}
         <p className="mb-10 max-w-xl text-xl leading-relaxed text-[#BAC2DE] sm:text-2xl">
           Stop duct-taping scripts together.
           <br />
           <span className="text-[#CDD6F4]">One command center. Every desktop action. Pure bash.</span>
         </p>
-
-        {/* Install command */}
         <div className="mb-10 w-full max-w-lg">
           <div className="group relative flex items-center rounded-lg border border-[#45475A] bg-[#181825] font-mono text-sm transition-colors hover:border-[#585B70]">
             <span className="select-none px-4 text-[#6C7086]">$</span>
@@ -61,16 +54,7 @@ export function Hero() {
               {copied ? (
                 <span className="text-[#A6E3A1]">copied!</span>
               ) : (
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
                   <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
                 </svg>
@@ -78,48 +62,18 @@ export function Hero() {
             </button>
           </div>
         </div>
-
-        {/* CTAs */}
         <div className="flex flex-col gap-4 sm:flex-row">
-          <Link
-            href="/docs/user/getting-started"
-            className="rounded-lg bg-[#CBA6F7] px-8 py-3.5 text-sm font-semibold text-[#1E1E2E] transition-all hover:bg-[#CBA6F7]/85 hover:shadow-lg hover:shadow-[#CBA6F7]/20"
-          >
+          <Link href="/docs/user/getting-started" className="rounded-lg bg-[#CBA6F7] px-8 py-3.5 text-sm font-semibold text-[#1E1E2E] transition-all hover:bg-[#CBA6F7]/85 hover:shadow-lg hover:shadow-[#CBA6F7]/20">
             Get Started
           </Link>
-          <a
-            href="https://github.com/shaiknoorullah/kall"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center justify-center gap-2 rounded-lg border border-[#45475A] px-8 py-3.5 text-sm font-semibold text-[#CDD6F4] transition-all hover:border-[#585B70] hover:bg-[#313244]/50"
-          >
-            <svg
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-            >
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-            </svg>
+          <a href="https://github.com/shaiknoorullah/kall" target="_blank" rel="noopener noreferrer" className="flex items-center justify-center gap-2 rounded-lg border border-[#45475A] px-8 py-3.5 text-sm font-semibold text-[#CDD6F4] transition-all hover:border-[#585B70] hover:bg-[#313244]/50">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" /></svg>
             GitHub
           </a>
         </div>
       </div>
-
-      {/* Scroll hint */}
       <div className="absolute bottom-8 left-1/2 -translate-x-1/2 animate-bounce text-[#6C7086]">
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <polyline points="6 9 12 15 18 9" />
-        </svg>
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="6 9 12 15 18 9" /></svg>
       </div>
     </section>
   );

--- a/website/components/landing/modules.tsx
+++ b/website/components/landing/modules.tsx
@@ -1,100 +1,57 @@
-type Module = {
-  name: string;
-  description: string;
-};
-
-type Category = {
-  label: string;
-  color: string;
-  modules: Module[];
-};
+type Module = { name: string; description: string };
+type Category = { label: string; color: string; modules: Module[] };
 
 const categories: Category[] = [
-  {
-    label: 'System',
-    color: '#F38BA8',
-    modules: [
-      { name: 'power', description: 'Shutdown, reboot, lock, suspend' },
-      { name: 'bluetooth', description: 'Scan, pair, connect devices' },
-      { name: 'network', description: 'Wi-Fi and connection manager' },
-      { name: 'audio', description: 'Sink and source switcher' },
-      { name: 'brightness', description: 'Display brightness control' },
-      { name: 'wallpaper', description: 'Browse and apply wallpapers' },
-    ],
-  },
-  {
-    label: 'Productivity',
-    color: '#A6E3A1',
-    modules: [
-      { name: 'clipboard', description: 'History, search, pin items' },
-      { name: 'emoji', description: 'Search and paste emoji' },
-      { name: 'screenshot', description: 'Region, window, fullscreen' },
-      { name: 'screenrecord', description: 'Record screen regions' },
-      { name: 'calculator', description: 'Quick math from the launcher' },
-    ],
-  },
-  {
-    label: 'Developer',
-    color: '#89B4FA',
-    modules: [
-      { name: 'tmux', description: 'Session picker and creator' },
-      { name: 'ssh', description: 'Connect to saved hosts' },
-      { name: 'docker', description: 'Manage containers and images' },
-      { name: 'git', description: 'Quick repo actions' },
-    ],
-  },
-  {
-    label: 'Browser',
-    color: '#FAB387',
-    modules: [
-      { name: 'websearch', description: 'Search from your launcher' },
-      { name: 'bookmarks', description: 'Browser bookmarks lookup' },
-      { name: 'tabs', description: 'Switch or close browser tabs' },
-    ],
-  },
-  {
-    label: 'Notes',
-    color: '#F5C2E7',
-    modules: [
-      { name: 'obsidian', description: 'Open vaults, search notes' },
-      { name: 'quicknote', description: 'Capture a thought instantly' },
-    ],
-  },
+  { label: 'System', color: '#F38BA8', modules: [
+    { name: 'power', description: 'Shutdown, reboot, lock, suspend' },
+    { name: 'bluetooth', description: 'Scan, pair, connect devices' },
+    { name: 'network', description: 'Wi-Fi and connection manager' },
+    { name: 'audio', description: 'Sink and source switcher' },
+    { name: 'brightness', description: 'Display brightness control' },
+    { name: 'wallpaper', description: 'Browse and apply wallpapers' },
+  ]},
+  { label: 'Productivity', color: '#A6E3A1', modules: [
+    { name: 'clipboard', description: 'History, search, pin items' },
+    { name: 'emoji', description: 'Search and paste emoji' },
+    { name: 'screenshot', description: 'Region, window, fullscreen' },
+    { name: 'screenrecord', description: 'Record screen regions' },
+    { name: 'calculator', description: 'Quick math from the launcher' },
+  ]},
+  { label: 'Developer', color: '#89B4FA', modules: [
+    { name: 'tmux', description: 'Session picker and creator' },
+    { name: 'ssh', description: 'Connect to saved hosts' },
+    { name: 'docker', description: 'Manage containers and images' },
+    { name: 'git', description: 'Quick repo actions' },
+  ]},
+  { label: 'Browser', color: '#FAB387', modules: [
+    { name: 'websearch', description: 'Search from your launcher' },
+    { name: 'bookmarks', description: 'Browser bookmarks lookup' },
+    { name: 'tabs', description: 'Switch or close browser tabs' },
+  ]},
+  { label: 'Notes', color: '#F5C2E7', modules: [
+    { name: 'obsidian', description: 'Open vaults, search notes' },
+    { name: 'quicknote', description: 'Capture a thought instantly' },
+  ]},
 ];
 
 export function Modules() {
   return (
     <section className="px-6 py-24">
       <div className="mx-auto max-w-5xl">
-        <h2 className="mb-4 text-center text-sm font-semibold uppercase tracking-widest text-[#CBA6F7]">
-          26 modules and counting
-        </h2>
-        <p className="mx-auto mb-16 max-w-lg text-center text-lg text-[#BAC2DE]">
-          Every action you reach for, already wired up.
-        </p>
-
+        <h2 className="mb-4 text-center text-sm font-semibold uppercase tracking-widest text-[#CBA6F7]">26 modules and counting</h2>
+        <p className="mx-auto mb-16 max-w-lg text-center text-lg text-[#BAC2DE]">Every action you reach for, already wired up.</p>
         <div className="space-y-10">
           {categories.map((category) => (
             <div key={category.label}>
               <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider">
-                <span
-                  className="inline-block h-2 w-2 rounded-full"
-                  style={{ backgroundColor: category.color }}
-                />
+                <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: category.color }} />
                 <span style={{ color: category.color }}>{category.label}</span>
               </h3>
               <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 {category.modules.map((mod) => (
-                  <div
-                    key={mod.name}
-                    className="flex items-baseline gap-3 rounded-lg border border-[#313244]/60 bg-[#181825]/40 px-4 py-3 transition-colors hover:border-[#45475A] hover:bg-[#181825]/80"
-                  >
-                    <code className="shrink-0 text-sm font-semibold text-[#CDD6F4]">
-                      {mod.name}
-                    </code>
-                    <span className="text-sm text-[#6C7086]">
-                      {mod.description}
-                    </span>
+                  <div key={mod.name} className="flex items-baseline gap-3 rounded-lg border border-[#313244]/60 bg-[#181825]/40 px-4 py-3 transition-colors hover:border-[#45475A] hover:bg-[#181825]/80">
+                    <code className="shrink-0 text-sm font-semibold text-[#CDD6F4]">{mod.name}</code>
+                    <span className="text-sm text-[#6C7086]">{mod.description}</span>
                   </div>
                 ))}
               </div>

--- a/website/components/landing/social-proof.tsx
+++ b/website/components/landing/social-proof.tsx
@@ -1,0 +1,39 @@
+export function SocialProof() {
+  return (
+    <section className="px-6 py-20">
+      <div className="mx-auto flex max-w-2xl flex-col items-center text-center">
+        <h2 className="mb-8 text-sm font-semibold uppercase tracking-widest text-[#CBA6F7]">
+          Open source
+        </h2>
+
+        {/* GitHub stars badge */}
+        <a
+          href="https://github.com/shaiknoorullah/kall"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mb-8 transition-opacity hover:opacity-80"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="https://img.shields.io/github/stars/shaiknoorullah/kall?style=for-the-badge&logo=github&labelColor=181825&color=CBA6F7"
+            alt="GitHub stars"
+            height="28"
+          />
+        </a>
+
+        <p className="mb-8 max-w-md text-lg text-[#BAC2DE]">
+          Built in the open. Shaped by the people who use it every day.
+        </p>
+
+        <a
+          href="https://github.com/shaiknoorullah/kall/discussions"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-lg border border-[#45475A] px-6 py-3 text-sm font-semibold text-[#CDD6F4] transition-all hover:border-[#585B70] hover:bg-[#313244]/50"
+        >
+          Join the community
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/website/components/landing/themes.tsx
+++ b/website/components/landing/themes.tsx
@@ -1,0 +1,50 @@
+type Palette = { name: string; colors: string[] };
+
+const palettes: Palette[] = [
+  { name: 'Catppuccin Mocha', colors: ['#1E1E2E', '#CBA6F7', '#89B4FA', '#A6E3A1', '#F38BA8', '#F9E2AF', '#CDD6F4'] },
+  { name: 'Dracula', colors: ['#282A36', '#BD93F9', '#FF79C6', '#50FA7B', '#FF5555', '#F1FA8C', '#F8F8F2'] },
+  { name: 'Nord', colors: ['#2E3440', '#88C0D0', '#81A1C1', '#A3BE8C', '#BF616A', '#EBCB8B', '#ECEFF4'] },
+  { name: 'Gruvbox', colors: ['#282828', '#D79921', '#458588', '#98971A', '#CC241D', '#D65D0E', '#EBDBB2'] },
+  { name: 'Tokyo Night', colors: ['#1A1B26', '#7AA2F7', '#BB9AF7', '#9ECE6A', '#F7768E', '#E0AF68', '#C0CAF5'] },
+  { name: 'Rose Pine', colors: ['#191724', '#C4A7E7', '#EBBCBA', '#31748F', '#EB6F92', '#F6C177', '#E0DEF4'] },
+];
+
+export function Themes() {
+  return (
+    <section className="px-6 py-24">
+      <div className="mx-auto max-w-4xl">
+        <h2 className="mb-4 text-center text-sm font-semibold uppercase tracking-widest text-[#CBA6F7]">
+          6 palettes built in
+        </h2>
+        <p className="mx-auto mb-6 max-w-lg text-center text-lg text-[#BAC2DE]">
+          Pick a palette. Or let your wallpaper decide.
+        </p>
+        <p className="mx-auto mb-14 max-w-md text-center text-sm text-[#6C7086]">
+          Dynamic wallbash theming extracts colors from your wallpaper and
+          applies them across every module, every backend, automatically.
+        </p>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {palettes.map((palette) => (
+            <div
+              key={palette.name}
+              className="rounded-xl border border-[#313244] bg-[#181825]/60 p-5 transition-all hover:border-[#45475A] hover:bg-[#181825]"
+            >
+              <p className="mb-3 text-sm font-medium text-[#CDD6F4]">{palette.name}</p>
+              <div className="flex gap-2">
+                {palette.colors.map((color, i) => (
+                  <div
+                    key={i}
+                    className="h-5 w-5 rounded-full border border-white/10"
+                    style={{ backgroundColor: color }}
+                    title={color}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/content/module-authors/authoring-guide.mdx
+++ b/website/content/module-authors/authoring-guide.mdx
@@ -1,0 +1,290 @@
+---
+title: Authoring Guide
+description: Step-by-step guide to creating, testing, and submitting a kall module.
+---
+
+This guide walks through the complete lifecycle of creating a kall module: scaffolding, writing the manifest, implementing the entry script, using lib functions, writing tests, and submitting a pull request.
+
+## Step 1: Scaffold the module
+
+Use the built-in scaffolding command to create a module skeleton:
+
+```bash
+kall create-module my-module
+```
+
+This creates three files:
+
+```
+modules/my-module/
+  module.yml         # Module manifest
+  my-module.sh       # Entry script
+tests/
+  test_my-module.bats  # Test file
+```
+
+The scaffold includes boilerplate for all three files so you can start writing logic immediately.
+
+## Step 2: Define the manifest
+
+Open `modules/my-module/module.yml` and fill in the metadata. The manifest is the contract between your module and the kall framework. Here is a complete example:
+
+```yaml
+name: my-module
+description: "Short description of what this module does"
+version: "1.0.0"
+author: "your-name"
+category: productivity
+
+platforms:
+  linux:
+    x11: true
+    wayland: true
+  macos: true
+
+requires:
+  lib: [menu, platform, notify]
+  adapter_tools:
+    x11: [xclip]
+    wayland: [wl-copy]
+    darwin: [pbcopy]
+
+keybinding:
+  mods: [mod, shift]
+  key: m
+
+config:
+  user_editable: [default_option]
+
+layout_hints:
+  columns: 1
+  icon_size: 24
+  show_preview: false
+```
+
+Every field except `name` is optional. See the [Module YAML Spec](/docs/module-authors/module-yml-spec) for a complete reference of every field.
+
+### Required fields
+
+Only `name` is strictly required. However, a well-defined module should include at minimum:
+
+- `name` -- unique identifier, must match the directory name
+- `description` -- shown in `kall list` output
+- `category` -- one of `system`, `productivity`, `developer`, `browser`, `notes`, `core`
+- `platforms` -- declares where the module works
+- `requires` -- declares runtime dependencies
+
+## Step 3: Write the entry script
+
+The entry script is a bash file that kall executes when the user runs `kall my-module`. It sources the kall library and uses lib functions to interact with the menu backend, clipboard, notifications, and other platform services.
+
+### Basic structure
+
+```bash
+#!/usr/bin/env bash
+# modules/my-module/my-module.sh
+
+set -euo pipefail
+
+# Source the kall core (loads all lib modules)
+# shellcheck source=../../lib/core.sh
+source "${KALL_LIB_DIR:-$(cd "$(dirname "$0")/../../lib" && pwd)}/core.sh"
+source "$KALL_LIB_DIR/menu.sh"
+source "$KALL_LIB_DIR/platform.sh"
+source "$KALL_LIB_DIR/notify.sh"
+
+# Build the menu items
+items="Option A\nOption B\nOption C"
+
+# Show the menu and capture the user's selection
+selected="$(echo -e "$items" | menu_dmenu "My Module")"
+
+# Exit if user cancelled (empty selection)
+[[ -z "$selected" ]] && exit 0
+
+# Handle the selection
+case "$selected" in
+  "Option A")
+    echo "result A" | clipboard_copy
+    notify "My Module" "Copied result A to clipboard"
+    ;;
+  "Option B")
+    open_url "https://example.com"
+    ;;
+  "Option C")
+    log_info "my-module: user selected option C"
+    ;;
+esac
+```
+
+### Key rules
+
+1. **Always source `core.sh` first.** It sets up environment detection, config parsing, and logging.
+2. **Never call platform tools directly.** Use `clipboard_copy` instead of `xclip`, `screenshot_area` instead of `grim`, etc. This is enforced by CI (invariant INV-MOD-03).
+3. **Handle empty selections.** When the user presses Escape or closes the menu, the menu function returns an empty string. Exit cleanly.
+4. **Use log functions for output.** Use `log_info`, `log_warn`, `log_error` instead of `echo >&2`. See the [Lib API](/docs/module-authors/lib-api) for all logging functions.
+
+## Step 4: Available lib functions
+
+kall provides a set of library functions organized by file. Source the relevant lib file and call its functions:
+
+### Menu functions (lib/menu.sh)
+
+| Function | Description |
+|---|---|
+| `menu_dmenu PROMPT` | Show a dmenu-style menu (pipe items via stdin) |
+| `menu_launch` | Launch the menu backend with full configuration |
+| `menu_calc` | Launch calculator mode |
+| `menu_keys` | Launch keybinding display mode |
+| `menu_supports FEATURE` | Check if the current backend supports a feature |
+
+### Platform functions (lib/platform.sh)
+
+| Function | Description |
+|---|---|
+| `clipboard_copy` | Copy stdin to clipboard (dispatches per session) |
+| `clipboard_paste` | Paste clipboard contents to stdout |
+| `screenshot_full PATH` | Take a full-screen screenshot |
+| `screenshot_area PATH` | Take an area-selection screenshot |
+| `screenshot_window PATH` | Take a screenshot of the active window |
+| `set_wallpaper PATH` | Set the desktop wallpaper |
+| `open_url URL` | Open a URL in the default browser |
+| `lock_screen` | Lock the screen (delegates to WM adapter) |
+
+### Notification functions (lib/notify.sh)
+
+| Function | Description |
+|---|---|
+| `notify TITLE [BODY]` | Send a standard 3-second notification |
+| `notify_critical TITLE [BODY]` | Send an urgent notification (no auto-dismiss) |
+| `notify_with_icon TITLE [BODY] [ICON]` | Send a notification with a custom icon |
+
+### Logging functions (lib/log.sh)
+
+| Function | Description |
+|---|---|
+| `log_trace MESSAGE` | Granular diagnostic (file:line format, debug.log only) |
+| `log_debug MESSAGE` | Diagnostic with file:line, debug.log only |
+| `log_info MESSAGE` | Normal operational message |
+| `log_warn MESSAGE` | Recoverable issue or fallback |
+| `log_error MESSAGE` | Failure that prevents an operation (always shown) |
+| `log_fatal MESSAGE` | Unrecoverable failure, exits with code 1 |
+
+### Core variables (lib/core.sh)
+
+| Variable | Description |
+|---|---|
+| `KALL_SESSION` | `x11`, `wayland`, or `darwin` |
+| `KALL_WM` | Detected window manager |
+| `KALL_OS` | `linux` or `darwin` |
+| `KALL_MENU_BACKEND` | Configured backend name |
+| `KALL_THEME` | Active palette name |
+
+For the full API reference with function signatures and examples, see [Lib API](/docs/module-authors/lib-api).
+
+## Step 5: Write tests
+
+Every module must have a test file. CI enforces this -- a module without `tests/test_<name>.bats` fails the build.
+
+Create `tests/test_my-module.bats`:
+
+```bash
+#!/usr/bin/env bats
+
+load test_helper/common
+
+setup() {
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+@test "my-module loads without errors" {
+  echo "Option A" > "$MENU_MOCK_OUTPUT"
+  run bash "$PROJECT_ROOT/modules/my-module/my-module.sh"
+  assert_success
+}
+
+@test "my-module copies result to clipboard on x11" {
+  export XDG_SESSION_TYPE=x11
+  echo "Option A" > "$MENU_MOCK_OUTPUT"
+  run bash "$PROJECT_ROOT/modules/my-module/my-module.sh"
+  assert_success
+  assert_mock_called "xclip"
+}
+
+@test "my-module copies result to clipboard on wayland" {
+  export XDG_SESSION_TYPE=wayland
+  echo "Option A" > "$MENU_MOCK_OUTPUT"
+  run bash "$PROJECT_ROOT/modules/my-module/my-module.sh"
+  assert_success
+  assert_mock_called "wl-copy"
+}
+
+@test "my-module handles empty selection" {
+  echo "" > "$MENU_MOCK_OUTPUT"
+  run bash "$PROJECT_ROOT/modules/my-module/my-module.sh"
+  assert_success
+}
+
+@test "my-module opens URL for Option B" {
+  echo "Option B" > "$MENU_MOCK_OUTPUT"
+  run bash "$PROJECT_ROOT/modules/my-module/my-module.sh"
+  assert_success
+  assert_mock_called "xdg-open"
+}
+```
+
+Run tests:
+
+```bash
+# Run all tests
+./tests/run_tests.sh
+
+# Run only your module's tests
+bats tests/test_my-module.bats
+
+# Run under a specific session type
+XDG_SESSION_TYPE=wayland bats tests/test_my-module.bats
+```
+
+For detailed information on the test infrastructure, mock system, and assertion helpers, see the [Testing Guide](/docs/module-authors/testing-guide).
+
+## Step 6: Submit a PR
+
+Before submitting, run the full validation suite locally:
+
+```bash
+# Lint
+shellcheck modules/my-module/my-module.sh
+shfmt -d -i 2 -ci modules/my-module/my-module.sh
+
+# Test
+./tests/run_tests.sh
+
+# Verify no direct platform tool calls
+grep -rn 'xclip\|wl-copy\|grim\|maim\|pbcopy' modules/my-module/ --include='*.sh' | grep -v '#'
+```
+
+### Commit convention
+
+Follow the project's conventional commit format:
+
+```
+feat(module/my-module): add my-module with clipboard integration
+```
+
+The format is `type(area/name): description`. See the [CI/CD](/docs/contributors/ci-cd) page for the full list of types and areas.
+
+### PR checklist
+
+Your PR should include:
+
+- `modules/my-module/module.yml` -- valid manifest with all relevant fields
+- `modules/my-module/my-module.sh` -- entry script using only lib functions
+- `tests/test_my-module.bats` -- test file covering success, failure, and platform branches
+- No direct calls to platform tools (`xclip`, `wl-copy`, `grim`, `maim`, `hyprctl`, `i3-msg`, `swaymsg`, `pbcopy`, `pbpaste`, `screencapture`, `xdotool`, `xrandr`)
+- shellcheck and shfmt clean
+- Tests pass on both X11 and Wayland session types

--- a/website/content/module-authors/module-yml-spec.mdx
+++ b/website/content/module-authors/module-yml-spec.mdx
@@ -1,0 +1,304 @@
+---
+title: Module YAML Spec
+description: Complete reference for every field in module.yml, with validation rules and examples.
+---
+
+The `module.yml` file is the manifest that every kall module ships. It declares metadata, platform compatibility, dependencies, keybindings, user-configurable options, and layout hints. The file is validated against `schemas/module.schema.yml` during installation and by CI.
+
+## Schema overview
+
+The schema version is `1.0`. All fields except `name` are optional.
+
+## Field reference
+
+### name
+
+**Type:** string (required)
+
+The unique module identifier. Must match the module's directory name. Used as the CLI command name (`kall <name>`).
+
+```yaml
+name: clipboard
+```
+
+Rules:
+- Lowercase alphanumeric characters and hyphens only
+- Must match the directory name under `modules/`
+- Must be unique across all modules
+
+### description
+
+**Type:** string
+
+A short, human-readable description displayed in `kall list` output and the module catalog.
+
+```yaml
+description: "Clipboard history manager with image support"
+```
+
+Keep it under 80 characters. Start with a noun or verb phrase, not "A module that...".
+
+### version
+
+**Type:** string
+
+The semantic version of the module. Follows the `major.minor.patch` format.
+
+```yaml
+version: "1.0.0"
+```
+
+### author
+
+**Type:** string
+
+The module author's name, handle, or organization.
+
+```yaml
+author: "shaiknoorullah"
+```
+
+### category
+
+**Type:** string (enum)
+
+The functional category for grouping in menus and the module catalog. Must be one of:
+
+| Value | Description |
+|---|---|
+| `system` | OS and hardware management (power, screenshot, bluetooth) |
+| `productivity` | Workflow and data tools (clipboard, calculator, emoji) |
+| `developer` | Development workflow (git, tmux, projects) |
+| `browser` | Web and browsing tools (websearch, bookmarks) |
+| `notes` | Note-taking and knowledge management (obsidian) |
+| `core` | Framework internals (dispatcher, not user-facing) |
+
+### layout
+
+**Type:** string
+
+The default menu layout style for this module. This is a hint to the backend adapter about how to render the menu.
+
+### platforms
+
+**Type:** object
+
+Declares which platforms the module supports.
+
+```yaml
+platforms:
+  linux:
+    x11: true
+    wayland: true
+  macos: true
+```
+
+| Key | Type | Description |
+|---|---|---|
+| `platforms.linux.x11` | boolean | Supports Linux with X11 display server |
+| `platforms.linux.wayland` | boolean | Supports Linux with Wayland display server |
+| `platforms.macos` | boolean | Supports macOS |
+
+Omitting a platform key is equivalent to `false`.
+
+### requires
+
+**Type:** object
+
+Declares runtime dependencies: kall lib modules and platform-specific tools.
+
+```yaml
+requires:
+  lib: [platform, menu, notify]
+  adapter_tools:
+    x11: [xclip, maim]
+    wayland: [wl-copy, grim, slurp]
+    darwin: [pbcopy]
+```
+
+#### requires.lib
+
+**Type:** string[]
+
+List of kall library modules that must be sourced. Common values:
+
+| Lib | Provides |
+|---|---|
+| `platform` | clipboard, screenshot, wallpaper, URL, lock functions |
+| `menu` | menu_dmenu, menu_launch, menu_calc, menu_keys, menu_supports |
+| `notify` | notify, notify_critical, notify_with_icon |
+| `theme` | load_theme, generate_wallbash, list_palettes, KALL_COLOR_* vars |
+| `keybinds` | _translate_keybind, inject_keybinds, remove_keybinds |
+
+#### requires.adapter_tools
+
+**Type:** object (session type -> string[])
+
+Maps session types (`x11`, `wayland`, `darwin`) to arrays of required system tool binaries. The `kall doctor` command checks these for the current session.
+
+### keybinding
+
+**Type:** object
+
+The default keyboard shortcut for this module.
+
+```yaml
+keybinding:
+  mods: [mod, shift]
+  key: e
+```
+
+#### keybinding.mods
+
+**Type:** string[]
+
+Array of modifier keys. Accepted values: `mod` (or `super`), `shift`, `ctrl`, `alt`.
+
+#### keybinding.key
+
+**Type:** string
+
+The key to bind. Examples: `e`, `v`, `Return`, `Print`, `1`, `space`, `period`.
+
+### config
+
+**Type:** object
+
+Declares module configuration metadata.
+
+```yaml
+config:
+  user_editable: [confirm_actions, default_engine]
+```
+
+#### config.user_editable
+
+**Type:** string[]
+
+List of configuration keys that users can override in `kall.yml`.
+
+### layout_hints
+
+**Type:** object
+
+Visual layout preferences that backend adapters honor when supported.
+
+```yaml
+layout_hints:
+  columns: 2
+  icon_size: 24
+  show_preview: true
+  preview: "chafa --size 40x20 {}"
+```
+
+| Key | Type | Description |
+|---|---|---|
+| `columns` | integer | Number of columns for grid layout |
+| `icon_size` | integer | Icon dimensions in pixels |
+| `show_preview` | boolean | Enable the preview pane |
+| `preview` | string | Preview command (fzf-style `{}` placeholder for the selected item) |
+
+## Complete examples
+
+### Simple module: power
+
+```yaml
+name: power
+description: "Shutdown, reboot, lock, suspend, hibernate"
+version: "1.0.0"
+author: "kall"
+category: system
+
+platforms:
+  linux:
+    x11: true
+    wayland: true
+  macos: true
+
+requires:
+  lib: [platform, menu, notify]
+  adapter_tools:
+    x11: [i3lock, slock]
+    wayland: [swaylock, hyprlock]
+    darwin: []
+
+keybinding:
+  mods: [mod, shift]
+  key: e
+
+config:
+  user_editable: [confirm_actions]
+
+layout_hints:
+  columns: 1
+  icon_size: 24
+  show_preview: false
+```
+
+Key characteristics:
+- Works on all platforms (X11, Wayland, macOS)
+- Lock screen tools are session-specific
+- macOS has no adapter tools (uses built-in `pmset` and AppleScript via lib functions)
+- Single-column list layout with icons, no preview
+
+### Complex module: websearch
+
+```yaml
+name: websearch
+description: "Search the web with autocomplete and multiple engines"
+version: "1.2.0"
+author: "kall"
+category: browser
+
+platforms:
+  linux:
+    x11: true
+    wayland: true
+  macos: true
+
+requires:
+  lib: [platform, menu, notify, theme]
+  adapter_tools:
+    x11: []
+    wayland: []
+    darwin: []
+
+keybinding:
+  mods: [mod]
+  key: s
+
+config:
+  user_editable: [default_engine, autocomplete, show_suggestions]
+
+layout_hints:
+  columns: 1
+  icon_size: 16
+  show_preview: true
+  preview: "curl -s 'https://api.duckduckgo.com/?q={}&format=json' | jq -r '.Abstract // \"No preview\"'"
+```
+
+Key characteristics:
+- No session-specific adapter tools (uses `open_url` which dispatches internally)
+- Preview pipeline fetches search summaries via curl and formats with jq
+- Multiple user-configurable options
+
+## Validation
+
+Module manifests are validated at two points:
+
+1. **Installation time** -- `kall add` validates against `schemas/module.schema.yml`
+2. **CI** -- the `validate` job checks all module manifests
+
+Run validation locally:
+
+```bash
+kall doctor
+```
+
+Common validation errors:
+
+| Error | Cause | Fix |
+|---|---|---|
+| Missing required field: name | `name` key absent | Add `name: <module-dir-name>` |
+| Invalid category | Category not in enum | Use one of: system, productivity, developer, browser, notes, core |
+| Name mismatch | `name` does not match directory | Rename the directory or the `name` field |

--- a/website/content/user/faq.mdx
+++ b/website/content/user/faq.mdx
@@ -1,0 +1,176 @@
+---
+title: FAQ
+description: Frequently asked questions about kall, its design, and compatibility.
+---
+
+## What does "kall" mean?
+
+"Kall" comes from the Scandinavian word for "call" or "summon." It reflects the tool's purpose: summoning menus, modules, and actions through a single command.
+
+## Why is kall written in bash?
+
+Bash is universal on Linux and macOS. It requires no runtime, no compilation, and no dependency management beyond the shell itself. Since kall's primary job is orchestrating CLI tools (menu launchers, clipboard managers, screenshot tools, notification daemons), bash is the natural language for that domain. Every target system already has it.
+
+kall does require bash 4+ for associative arrays and other modern features. macOS ships bash 3.x, so Homebrew users need to install a newer version (`brew install bash`).
+
+## Does kall replace rofi?
+
+No. kall uses rofi (or any other supported launcher) as a backend. Rofi renders the menu UI; kall provides the module logic, theming, keybinding translation, and cross-platform abstraction on top of it. You can swap rofi for wofi, fzf, fuzzel, tofi, or dmenu without changing any module code.
+
+## Can I use only some modules?
+
+Yes. kall is fully modular. Install only what you need:
+
+```bash
+kall add power clipboard screenshot
+```
+
+During installation, pick the "minimal" preset (5 modules) or choose individual modules from the list. Unused modules are not loaded, not sourced, and have no runtime cost.
+
+## Can I switch menu backends?
+
+Yes. Change the `menu_backend` key in `kall.yml`:
+
+```yaml
+menu_backend: fzf
+```
+
+Or from the command line:
+
+```bash
+kall theme set-backend fzf
+```
+
+All modules work with every backend. Layout hints (icons, columns, preview panes) degrade gracefully when the backend does not support them. For example, fzf supports preview pipelines but not icons; dmenu supports neither.
+
+Supported backends: `rofi`, `wofi`, `fuzzel`, `tofi`, `dmenu`, `fzf`.
+
+## Can I disable kall's styling?
+
+Yes. If you want your system theme, compositor, or WM to handle all visual appearance:
+
+```yaml
+appearance:
+  managed: false
+```
+
+This disables all appearance arguments kall passes to the menu backend. The launcher renders with its own default theme.
+
+You can also disable individual properties:
+
+```yaml
+appearance:
+  managed: true
+  font: "JetBrainsMono Nerd Font 12"
+  icon_theme: false
+  border_radius: false
+  border_width: 2
+  opacity: false
+```
+
+Any property set to `false` is skipped entirely -- kall does not pass that argument to the backend.
+
+## What are the hard dependencies?
+
+kall has three hard dependencies that every installation requires:
+
+| Dependency | Purpose |
+|---|---|
+| A menu launcher | Render menus. At least one of: rofi, wofi, fuzzel, tofi, dmenu, fzf |
+| `yq` | Parse YAML configuration and module manifests (Go-based, by Mike Farah) |
+| `jq` | Parse JSON output from system tools and APIs |
+
+Everything else is per-module. Each module declares its own dependencies in `module.yml` under `requires.adapter_tools`. The `kall doctor` command shows which tools are missing for your installed modules.
+
+Common per-module dependencies include:
+
+| Tool | Used by | Session |
+|---|---|---|
+| `xclip` | clipboard, screenshot | X11 |
+| `wl-copy` / `wl-paste` | clipboard, screenshot | Wayland |
+| `grim` + `slurp` | screenshot | Wayland |
+| `maim` | screenshot | X11 |
+| `playerctl` | media | All |
+| `bluetoothctl` | bluetooth | Linux |
+| `systemctl` | systemd, power | Linux |
+| `ImageMagick` | wallbash (dynamic theming) | All |
+
+## Does kall work on macOS?
+
+Yes, with limitations. kall detects macOS via `uname` and sets `KALL_OS=darwin` and `KALL_SESSION=darwin`. Platform-specific lib functions dispatch to macOS equivalents:
+
+| Function | macOS tool |
+|---|---|
+| `clipboard_copy` | `pbcopy` |
+| `clipboard_paste` | `pbpaste` |
+| `screenshot_full` | `screencapture` |
+| `screenshot_area` | `screencapture -s` |
+| `screenshot_window` | `screencapture -w` |
+| `open_url` | `open` |
+| `set_wallpaper` | `osascript` (Finder AppleScript) |
+| `notify` | `osascript` (notification center) |
+
+Some modules are unavailable on macOS because they depend on Linux-only subsystems:
+
+- **display** -- requires `xrandr` or Wayland protocols for monitor management
+- **bluetooth** -- requires `bluetoothctl` (Linux BlueZ stack)
+- **systemd** -- requires `systemctl` (Linux init system)
+- **notifications** -- requires `notify-send` / libnotify
+
+Each module declares its platform support in `module.yml`. The `kall list` command only shows modules compatible with your detected platform.
+
+For keybindings on macOS, kall generates skhd syntax:
+
+```
+shift + cmd - e : kall power
+```
+
+## How do I update kall?
+
+If you installed via the curl installer or GitHub release:
+
+```bash
+kall update
+```
+
+If you installed via a package manager:
+
+```bash
+# AUR
+yay -Syu kall
+
+# Homebrew
+brew upgrade kall
+```
+
+## Can I create my own modules?
+
+Yes. See the [Module Authors](/docs/module-authors) section for a complete guide. The short version:
+
+```bash
+kall create-module my-module
+```
+
+This scaffolds a module directory with `module.yml`, an entry script, and a test file. Write your logic using kall's lib functions (`menu_launch`, `clipboard_copy`, `notify`, etc.) and submit a PR.
+
+## Where are logs stored?
+
+Log files live in `$XDG_STATE_HOME/kall/logs/` (default: `~/.local/state/kall/logs/`):
+
+- **kall.log** -- INFO-level and above messages from normal operation
+- **debug.log** -- all log levels, only written when debug mode is active (`kall --debug`)
+
+Logs rotate automatically when `kall.log` exceeds 1 MB (configurable). See [Troubleshooting](/docs/user/troubleshooting) for details.
+
+## How do I report a bug?
+
+Open an issue on [GitHub](https://github.com/shaiknoorullah/kall/issues) using the bug report template. Include:
+
+1. Output of `kall doctor`
+2. Your `kall.yml` (remove any sensitive data)
+3. Relevant log entries from `~/.local/state/kall/logs/kall.log`
+4. If possible, debug output: `kall --debug <module> 2>debug-output.txt`
+
+## Does kall phone home or collect telemetry?
+
+No. kall makes no network requests except those explicitly initiated by modules (e.g., the websearch module opens a URL in your browser, the weather module queries wttr.in). There is no analytics, no crash reporting, and no update checking. The `kall update` command is the only network operation in the framework itself.

--- a/website/content/user/keybindings.mdx
+++ b/website/content/user/keybindings.mdx
@@ -1,0 +1,211 @@
+---
+title: Keybindings
+description: Bind kall modules to keyboard shortcuts across window managers using the normalized keybinding system.
+---
+
+kall uses a normalized keybinding format that translates to the native syntax of each supported window manager. You define bindings once in `module.yml` using a generic modifier + key format, and kall generates WM-specific configuration lines that can be injected into your WM config file.
+
+## Keybinding format
+
+Keybindings are declared in each module's `module.yml` under the `keybinding` key:
+
+```yaml
+keybinding:
+  mods: [mod, shift]
+  key: e
+```
+
+The `mods` array accepts these normalized modifier names:
+
+| Modifier | Meaning |
+|---|---|
+| `mod` / `super` | The Super/Windows/Command key |
+| `shift` | Shift key |
+| `ctrl` | Control key |
+| `alt` | Alt/Option key |
+
+The `key` field is the literal key name (e.g., `e`, `Return`, `1`, `space`).
+
+## Managing keybindings
+
+kall provides four subcommands for keybinding management:
+
+### Show keybindings
+
+Display all module keybindings translated for the detected window manager:
+
+```bash
+kall keybinds show
+```
+
+Output example on Hyprland:
+
+```
+power:       bind = $mainMod SHIFT, E, exec, kall power
+clipboard:   bind = $mainMod, V, exec, kall clipboard
+screenshot:  bind = $mainMod, PRINT, exec, kall screenshot
+```
+
+### Inject keybindings
+
+Write keybinding lines into your WM configuration file:
+
+```bash
+kall keybinds inject
+```
+
+Injected bindings are wrapped in block markers so kall can locate and update them later:
+
+```
+# >>> kall keybinds >>>
+bind = $mainMod SHIFT, E, exec, kall power
+bind = $mainMod, V, exec, kall clipboard
+bind = $mainMod, PRINT, exec, kall screenshot
+# <<< kall keybinds <<<
+```
+
+The block markers (`# >>> kall keybinds >>>` and `# <<< kall keybinds <<<`) are preserved across re-injections. Running `inject` again replaces the block contents with the current set of module keybindings.
+
+### Export keybindings
+
+Print keybinding lines to stdout without modifying any file:
+
+```bash
+kall keybinds export
+```
+
+This is useful for manual pasting or piping into other tools.
+
+### Remove keybindings
+
+Remove the kall keybinding block from your WM configuration:
+
+```bash
+kall keybinds remove
+```
+
+This deletes everything between the block markers (inclusive), leaving the rest of your config untouched.
+
+## Supported window managers
+
+kall translates keybindings for six window managers and compositors. The translation is handled by `_translate_keybind()` in `lib/keybinds.sh`. Given the example binding `mods: [mod, shift]`, `key: e`, `command: kall power`, each WM produces:
+
+### Hyprland
+
+```ini
+bind = $mainMod SHIFT, E, exec, kall power
+```
+
+Config file: `~/.config/hypr/hyprland.conf`
+
+Modifiers are translated to Hyprland's format: `mod`/`super` becomes `$mainMod`, keys are uppercased, and the command is prefixed with `exec,`.
+
+### i3
+
+```ini
+bindsym $mod+Shift+e exec kall power
+```
+
+Config file: `~/.config/i3/config`
+
+Modifiers are joined with `+`: `mod`/`super` becomes `$mod`, `shift` becomes `Shift`, `alt` becomes `Mod1`. The key follows directly after.
+
+### sway
+
+```ini
+bindsym $mod+Shift+e exec kall power
+```
+
+Config file: `~/.config/sway/config`
+
+Sway uses the same syntax as i3. The translation function handles both identically.
+
+### bspwm (sxhkd)
+
+```
+super + shift + e
+	kall power
+```
+
+Config file: `~/.config/sxhkd/sxhkdrc`
+
+bspwm uses sxhkd for keybindings. Modifiers are space-separated with ` + ` between them, and the command is indented on the next line with a tab.
+
+### awesome
+
+```lua
+awful.key({ modkey, "Shift" }, "e", function() awful.spawn("kall power") end)
+```
+
+Config file: `~/.config/awesome/rc.lua`
+
+Modifiers are listed in a Lua table: `mod`/`super` becomes `modkey`, others are quoted strings. The command is wrapped in `awful.spawn()`.
+
+### skhd (macOS)
+
+```
+shift + cmd - e : kall power
+```
+
+Config file: `~/.config/skhd/skhdrc`
+
+macOS uses skhd for keyboard shortcuts. `mod`/`super` becomes `cmd`, modifiers use ` + ` separators, a ` - ` precedes the key, and ` : ` separates the key from the command.
+
+## Translation details
+
+The `_translate_keybind` function in `lib/keybinds.sh` accepts four arguments:
+
+```bash
+_translate_keybind WM MODS_CSV KEY COMMAND
+```
+
+- **WM** -- one of: `hyprland`, `i3`, `sway`, `bspwm`, `awesome`, `skhd`
+- **MODS_CSV** -- comma-separated modifiers: `mod,shift` or `mod`
+- **KEY** -- the key to bind: `e`, `Return`, `1`, etc.
+- **COMMAND** -- the full command: `kall power`
+
+For unrecognized window managers, the function outputs a comment:
+
+```bash
+# kall power (bind mod,shift + e)
+```
+
+## Example module keybindings
+
+Here are typical keybindings across several modules:
+
+| Module | Mods | Key | What it does |
+|---|---|---|---|
+| power | mod, shift | e | Open the power menu |
+| clipboard | mod | v | Open clipboard history |
+| screenshot | mod | Print | Open the screenshot menu |
+| wallpaper | mod, shift | w | Open the wallpaper browser |
+| websearch | mod | s | Open web search |
+| emoji | mod | period | Open the emoji picker |
+
+Each module ships its own default keybinding in `module.yml`. Users can override these defaults per-module in `kall.yml`:
+
+```yaml
+modules:
+  power:
+    keybinding:
+      mods: [mod, ctrl]
+      key: q
+```
+
+## Multiple WMs
+
+If you use different WMs on different machines (e.g., Hyprland at home, i3 at work), kall auto-detects the active WM via `XDG_CURRENT_DESKTOP` and translates keybindings accordingly. The normalized format in `module.yml` stays the same -- only the generated output changes.
+
+## Manual configuration
+
+You are not required to use `kall keybinds inject`. You can copy the output of `kall keybinds export` and paste it into your WM config manually. The `export` command is a read-only operation that makes no changes to your system.
+
+For WMs not in the supported list, `kall keybinds export` prints a commented format that documents the intended binding:
+
+```bash
+# kall power (bind mod,shift + e)
+# kall clipboard (bind mod + v)
+```
+
+You can then translate these comments to your WM's native syntax.

--- a/website/content/user/modules.mdx
+++ b/website/content/user/modules.mdx
@@ -1,0 +1,155 @@
+---
+title: Modules
+description: Catalog of all 26 kall modules with platform support and categories.
+---
+
+## Module catalog
+
+kall ships 26 modules at launch, organized by category. Platform support indicates where each module works:
+
+- **X11** -- Linux with X11 display server
+- **Wayland** -- Linux with Wayland display server
+- **macOS** -- macOS (with skhd/yabai or standalone)
+
+### Core -- Launchers and navigation
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| launcher | App launcher (drun, run, window, filebrowser) | Y | Y | Y |
+| style-selector | Visual launcher style switcher (12 styles) | Y | Y | Y |
+| keybindings | WM keybinding cheat sheet viewer | Y | Y | ~ |
+
+### System -- Hardware, display, power
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| power | Shutdown, reboot, lock, suspend, logout | Y | Y | Y |
+| screenshot | Full, area, window capture + clipboard + OCR | Y | Y | Y |
+| clipboard | History, favorites, image preview, OCR scan | Y | Y | Y |
+| display | Multi-monitor layout manager | Y | Y | -- |
+| wallpaper | Category browser + setter + dynamic theme trigger | Y | Y | Y |
+| bluetooth | Scan, pair, connect, trust devices | Y | Y | -- |
+| systemd | Service manager (start, stop, enable, disable) | Y | Y | -- |
+
+### Productivity -- Search, calculate, pick
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| websearch | Search with autocomplete + bang syntax | Y | Y | Y |
+| calculator | Calculator mode | Y | Y | Y |
+| emoji | Emoji picker with recents + grid/list | Y | Y | Y |
+| glyph | Nerd Font glyph picker | Y | Y | Y |
+| media | Media player controls (play, pause, next, prev) | Y | Y | Y |
+
+### Developer -- Git, tmux, projects
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| git-profiles | Switch git user.name/email per project | Y | Y | Y |
+| tmux | Tmux session manager | Y | Y | Y |
+| projects | Project directory launcher (editor + terminal) | Y | Y | Y |
+
+### Browser -- Zen, bookmarks, search
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| bookmarks | Browser bookmarks viewer (Firefox, Chrome, Zen) | Y | Y | Y |
+| zen-tabs | Fuzzy tab search with favicon preview | Y | Y | Y |
+| zen-workspaces | Domain-based tab grouping + dedup | Y | Y | Y |
+
+### Notes -- Obsidian
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| obsidian | Quick actions (new note, daily, open vault) | Y | Y | Y |
+| obsidian-search | Full-text note search with preview | Y | Y | Y |
+
+### Additional modules
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| weather | Weather display (wttr.in API) | Y | Y | Y |
+| notifications | Notification history viewer | Y | Y | -- |
+| theme-selector | Theme/palette browser with preview | Y | Y | Y |
+
+**Legend:** Y = supported, ~ = partial support, -- = not available
+
+## Managing modules
+
+```bash
+# Install modules
+kall add emoji calculator tmux
+
+# Remove a module
+kall remove zen-workspaces
+
+# List installed modules
+kall list
+
+# List all available modules for your platform
+kall list --available
+```
+
+When you run `kall add`, kall reads the module's `module.yml`, checks platform compatibility, installs any missing dependencies via your system's package manager, adds the module to your `kall.yml`, and copies any user-editable config files.
+
+## Module groups
+
+Groups aggregate multiple modules into a single navigable menu. kall ships five groups:
+
+| Group | Members |
+|---|---|
+| system | power, display, bluetooth, systemd |
+| productivity | websearch, calculator, emoji, glyph, media |
+| developer | git-profiles, tmux, projects |
+| browser | bookmarks, zen-tabs, zen-workspaces |
+| notes | obsidian, obsidian-search |
+
+```bash
+# Open a group
+kall system
+
+# Jump to a specific module within a group
+kall system power
+```
+
+You can define custom groups in your `kall.yml`. See [Configuration](/docs/user/configuration) for details.
+
+## Module structure
+
+Every module lives in its own directory under `modules/` and contains:
+
+```
+modules/<name>/
+  module.yml        # Module manifest (required)
+  <name>.sh         # Entry script (required)
+  assets/           # Icons, preview scripts (optional)
+```
+
+The `module.yml` manifest declares metadata, platform compatibility, dependencies, default keybinding, and layout hints. See the [Module YAML Spec](/docs/module-authors/module-yml-spec) for a full field reference.
+
+## Dependencies
+
+Modules declare two kinds of dependencies in `module.yml`:
+
+### Lib dependencies
+
+The `requires.lib` array lists kall library modules needed at runtime:
+
+```yaml
+requires:
+  lib: [platform, menu, notify]
+```
+
+### Adapter tool dependencies
+
+The `requires.adapter_tools` object maps session types to required system tools:
+
+```yaml
+requires:
+  adapter_tools:
+    x11: [xclip, maim]
+    wayland: [wl-copy, grim, slurp]
+    darwin: [pbcopy]
+```
+
+The `kall doctor` command checks that all tools required by installed modules are present on the system.

--- a/website/content/user/themes.mdx
+++ b/website/content/user/themes.mdx
@@ -1,0 +1,255 @@
+---
+title: Themes
+description: Color palettes, dynamic wallbash theming, and custom palette creation.
+---
+
+kall ships six curated color palettes and supports dynamic color extraction from your wallpaper. Palettes define eight canonical color slots that map to semantic roles in every menu backend. This page covers the built-in palettes, theme management commands, wallbash dynamic theming, and how to create your own palette.
+
+## Built-in palettes
+
+Six palettes are included in `themes/palettes/`:
+
+### Catppuccin Mocha
+
+A warm, pastel dark theme from the Catppuccin project.
+
+| Color slot | Hex | Role |
+|---|---|---|
+| `main_bg` | `#1E1E2E` | Primary background |
+| `main_fg` | `#CDD6F4` | Primary foreground |
+| `main_br` | `#CBA6F7` | Border / accent (mauve) |
+| `main_ex` | `#F5E0DC` | Extra accent (rosewater) |
+| `select_bg` | `#B4BEFE` | Selected item background (lavender) |
+| `select_fg` | `#1E1E2E` | Selected item foreground |
+| `urgent_bg` | `#F38BA8` | Urgent background (red) |
+| `urgent_fg` | `#1E1E2E` | Urgent foreground |
+
+### Dracula
+
+The classic Dracula dark palette.
+
+| Color slot | Hex | Role |
+|---|---|---|
+| `main_bg` | `#282A36` | Primary background |
+| `main_fg` | `#F8F8F2` | Primary foreground |
+| `main_br` | `#BD93F9` | Border / accent (purple) |
+| `main_ex` | `#FF79C6` | Extra accent (pink) |
+| `select_bg` | `#44475A` | Selected item background |
+| `select_fg` | `#F8F8F2` | Selected item foreground |
+| `urgent_bg` | `#FF5555` | Urgent background (red) |
+| `urgent_fg` | `#F8F8F2` | Urgent foreground |
+
+### Nord
+
+Arctic, north-bluish palette by Arctic Ice Studio.
+
+| Color slot | Hex | Role |
+|---|---|---|
+| `main_bg` | `#2E3440` | Primary background (Polar Night) |
+| `main_fg` | `#ECEFF4` | Primary foreground (Snow Storm) |
+| `main_br` | `#88C0D0` | Border / accent (Frost) |
+| `main_ex` | `#81A1C1` | Extra accent (Frost) |
+| `select_bg` | `#4C566A` | Selected item background |
+| `select_fg` | `#ECEFF4` | Selected item foreground |
+| `urgent_bg` | `#BF616A` | Urgent background (Aurora red) |
+| `urgent_fg` | `#ECEFF4` | Urgent foreground |
+
+### Gruvbox
+
+Retro groove palette by morhetz.
+
+| Color slot | Hex | Role |
+|---|---|---|
+| `main_bg` | `#282828` | Primary background (dark0) |
+| `main_fg` | `#EBDBB2` | Primary foreground (light1) |
+| `main_br` | `#D79921` | Border / accent (yellow) |
+| `main_ex` | `#458588` | Extra accent (blue) |
+| `select_bg` | `#504945` | Selected item background (dark2) |
+| `select_fg` | `#EBDBB2` | Selected item foreground |
+| `urgent_bg` | `#CC241D` | Urgent background (red) |
+| `urgent_fg` | `#EBDBB2` | Urgent foreground |
+
+### Tokyo Night
+
+Dark theme inspired by Tokyo city lights, by enkia.
+
+| Color slot | Hex | Role |
+|---|---|---|
+| `main_bg` | `#1A1B26` | Primary background |
+| `main_fg` | `#C0CAF5` | Primary foreground |
+| `main_br` | `#7AA2F7` | Border / accent (blue) |
+| `main_ex` | `#BB9AF7` | Extra accent (purple) |
+| `select_bg` | `#33467C` | Selected item background |
+| `select_fg` | `#C0CAF5` | Selected item foreground |
+| `urgent_bg` | `#F7768E` | Urgent background (red) |
+| `urgent_fg` | `#C0CAF5` | Urgent foreground |
+
+### Rose Pine
+
+Natural, muted palette from the Rose Pine project.
+
+| Color slot | Hex | Role |
+|---|---|---|
+| `main_bg` | `#191724` | Primary background (base) |
+| `main_fg` | `#E0DEF4` | Primary foreground (text) |
+| `main_br` | `#C4A7E7` | Border / accent (iris) |
+| `main_ex` | `#EBBCBA` | Extra accent (rose) |
+| `select_bg` | `#26233A` | Selected item background (overlay) |
+| `select_fg` | `#E0DEF4` | Selected item foreground |
+| `urgent_bg` | `#EB6F92` | Urgent background (love) |
+| `urgent_fg` | `#E0DEF4` | Urgent foreground |
+
+## Theme commands
+
+### Set active theme
+
+Switch to a different palette:
+
+```bash
+kall theme set dracula
+```
+
+This updates the `theme` key in `kall.yml` and regenerates backend-specific theme files.
+
+### List available palettes
+
+Show all palettes in `themes/palettes/`:
+
+```bash
+kall theme list
+```
+
+Output:
+
+```
+catppuccin-mocha
+dracula
+gruvbox
+nord
+rose-pine
+tokyo-night
+```
+
+## Dynamic wallbash
+
+Wallbash is an opt-in dynamic theming mode that extracts dominant colors from your current wallpaper instead of using a curated palette. It requires ImageMagick.
+
+### Enabling wallbash
+
+```bash
+kall theme wallbash on
+```
+
+This sets `dynamic_theme: true` in `kall.yml`. The next time any module runs, the theme engine calls `generate_wallbash()` instead of `load_theme()`.
+
+### How it works
+
+The `generate_wallbash()` function in `lib/theme.sh` performs these steps:
+
+1. **Resize** the wallpaper image to 100x100 pixels (forced aspect ratio) for fast processing
+2. **Quantize** to 8 dominant colors using ImageMagick color reduction: `convert "$wallpaper" -resize 100x100! -colors 8 -unique-colors txt:-`
+3. **Extract** hex color codes from the output
+4. **Sort by luminance** using BT.601 coefficients (`R * 299 + G * 587 + B * 114`)
+5. **Map** sorted colors to `KALL_COLOR_*` variables (darkest to backgrounds, lightest to foregrounds)
+
+The luminance-based mapping:
+
+| Sort position | Variable | Role |
+|---|---|---|
+| 1 (darkest) | `KALL_COLOR_MAIN_BG` | Primary background |
+| 2 | `KALL_COLOR_SELECT_BG` | Selected item background |
+| 4 | `KALL_COLOR_URGENT_BG` | Urgent background |
+| 5 | `KALL_COLOR_MAIN_EX` | Extra accent |
+| 6 | `KALL_COLOR_MAIN_BR` | Border accent |
+| 7 | `KALL_COLOR_SELECT_FG` | Selected item foreground |
+| 8 (lightest) | `KALL_COLOR_MAIN_FG`, `KALL_COLOR_URGENT_FG` | Primary and urgent foreground |
+
+### Fallback behavior
+
+Wallbash falls back to the static palette (the `theme` value in `kall.yml`) in three cases:
+
+- The wallpaper file does not exist
+- ImageMagick (`convert`) is not installed
+- Color extraction produces fewer than 8 colors
+
+The fallback is automatic and silent except for a `WARN`-level log entry.
+
+### Disabling wallbash
+
+```bash
+kall theme wallbash off
+```
+
+This sets `dynamic_theme: false` and reverts to the static palette.
+
+## Creating a custom palette
+
+### Step 1: Copy an existing palette
+
+Start from a palette close to what you want:
+
+```bash
+cp themes/palettes/catppuccin-mocha.yml themes/palettes/my-theme.yml
+```
+
+### Step 2: Edit the colors
+
+Open the file and replace the hex values. All eight color keys under `colors` are required:
+
+```yaml
+name: "My Custom Theme"
+author: "your-name"
+
+colors:
+  main_bg: "#1a1b26"
+  main_fg: "#c0caf5"
+  main_br: "#7aa2f7"
+  main_ex: "#bb9af7"
+  select_bg: "#283457"
+  select_fg: "#c0caf5"
+  urgent_bg: "#f7768e"
+  urgent_fg: "#1a1b26"
+```
+
+The schema (`schemas/palette.schema.yml`) enforces that `name`, `main_bg`, `main_fg`, `main_br`, `main_ex`, `select_bg`, and `select_fg` are all required. Omitting any key fails validation.
+
+### Step 3: Validate
+
+Run the doctor command to check schema compliance:
+
+```bash
+kall doctor
+```
+
+### Step 4: Generate backend themes
+
+Regenerate theme files for all backends:
+
+```bash
+./backends/generate-themes.sh
+```
+
+This reads your new palette and creates theme files in every backend's `themes/` directory (`.rasi` for rofi, `.css` for wofi, `.sh` for fzf and dmenu, `.ini` for tofi and fuzzel).
+
+### Step 5: Activate
+
+```bash
+kall theme set my-theme
+```
+
+## Color variable reference
+
+After theme loading (static or wallbash), these environment variables are available to all lib functions and backend adapters:
+
+| Variable | Palette key | Semantic role |
+|---|---|---|
+| `KALL_COLOR_MAIN_BG` | `colors.main_bg` | Primary background |
+| `KALL_COLOR_MAIN_FG` | `colors.main_fg` | Primary foreground / text |
+| `KALL_COLOR_MAIN_BR` | `colors.main_br` | Border and accent color |
+| `KALL_COLOR_MAIN_EX` | `colors.main_ex` | Extra accent (highlights, badges) |
+| `KALL_COLOR_SELECT_BG` | `colors.select_bg` | Selected item background |
+| `KALL_COLOR_SELECT_FG` | `colors.select_fg` | Selected item foreground |
+| `KALL_COLOR_URGENT_BG` | `colors.urgent_bg` | Urgent / error background |
+| `KALL_COLOR_URGENT_FG` | `colors.urgent_fg` | Urgent / error foreground |
+
+Modules never read these variables directly. They declare layout hints and the backend adapter handles color application.

--- a/website/content/user/troubleshooting.mdx
+++ b/website/content/user/troubleshooting.mdx
@@ -1,0 +1,203 @@
+---
+title: Troubleshooting
+description: Debug mode, log files, kall doctor, log rotation, and common issues.
+---
+
+When something goes wrong with kall, the structured logging system and built-in diagnostic tool provide the information needed to identify and resolve problems.
+
+## Debug mode
+
+Run any kall command with the `--debug` flag to enable verbose diagnostic output:
+
+```bash
+kall --debug power
+kall --debug clipboard
+kall --debug doctor
+```
+
+Debug mode sets the log level to `DEBUG` (numeric level 1), which causes two things:
+
+1. **All log messages** (including `TRACE` and `DEBUG`) are written to `debug.log`
+2. **Debug-level messages** include the source file and line number in the log format
+
+Normal log format (INFO and above):
+
+```
+[INFO] 2026-03-14 12:30:45  clipboard module loaded
+```
+
+Debug log format (DEBUG and TRACE):
+
+```
+[DEBUG] 2026-03-14 12:30:45.123 core.sh:42  OS=linux SESSION=wayland WM=hyprland BACKEND=rofi THEME=catppuccin-mocha
+[TRACE] 2026-03-14 12:30:45.124 platform.sh:51  clipboard_copy dispatching to wl-copy
+```
+
+The millisecond timestamp and `file:line` reference make it possible to trace exactly which code path executed.
+
+## Log files
+
+kall writes logs to `$XDG_STATE_HOME/kall/logs/`, which defaults to `~/.local/state/kall/logs/`. Two log files are maintained:
+
+### kall.log
+
+The primary log file. It receives messages at `INFO` level and above (`INFO`, `WARN`, `ERROR`, `FATAL`). Debug and trace messages are never written here, per invariant INV-LOG-02.
+
+```bash
+tail -50 ~/.local/state/kall/logs/kall.log
+```
+
+### debug.log
+
+The verbose log file. It receives all log levels (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`), but only when debug mode is active (log level set to `DEBUG` or `TRACE`).
+
+```bash
+tail -100 ~/.local/state/kall/logs/debug.log
+```
+
+If you have never run kall in debug mode, `debug.log` may not exist.
+
+### Log level hierarchy
+
+| Level | Numeric | Written to kall.log | Written to debug.log | Shown on stderr |
+|---|---|---|---|---|
+| `TRACE` | 0 | No | Yes (if debug active) | Only if log level is TRACE |
+| `DEBUG` | 1 | No | Yes (if debug active) | Only if log level is DEBUG or lower |
+| `INFO` | 2 | Yes | Yes (if debug active) | If log level is INFO or lower |
+| `WARN` | 3 | Yes | Yes (if debug active) | If log level is WARN or lower |
+| `ERROR` | 4 | Yes | Yes (if debug active) | Always |
+| `FATAL` | 5 | Yes | Yes (if debug active) | Always (then exits) |
+
+`ERROR` and `FATAL` messages are always shown on stderr regardless of the configured log level.
+
+## kall doctor
+
+The `doctor` command performs a comprehensive health check of your kall installation:
+
+```bash
+kall doctor
+```
+
+It validates:
+
+- **Configuration** -- checks that `kall.yml` exists and parses correctly against the config schema
+- **Core dependencies** -- verifies that `yq` and `jq` are installed
+- **Menu backend** -- checks that the configured backend binary exists
+- **Module dependencies** -- for each installed module, checks that all declared `requires.adapter_tools` for the current session type are installed
+- **Palette validity** -- validates palette files against `schemas/palette.schema.yml`
+- **Config version** -- detects outdated `kall.yml` format and suggests migration steps
+
+Example output:
+
+```
+[OK]   kall.yml found at ~/.config/kall/kall.yml
+[OK]   yq installed (v4.35.1)
+[OK]   jq installed (jq-1.7)
+[OK]   rofi installed
+[OK]   Module: power -- all deps satisfied
+[OK]   Module: clipboard -- all deps satisfied
+[WARN] Module: screenshot -- missing: slurp (wayland area selection)
+[OK]   Palette: catppuccin-mocha -- valid
+[OK]   Config version: current
+```
+
+Warnings indicate optional or degraded functionality. Errors indicate problems that will prevent modules from working.
+
+## Log rotation
+
+kall rotates `kall.log` when it exceeds the configured size threshold. Rotation is handled by `_kall_log_rotate()` in `lib/log.sh`.
+
+### How it works
+
+1. At startup, kall checks the size of `kall.log`
+2. If the file exceeds `KALL_LOG_MAX_SIZE_MB` (default: 1 MB), rotation triggers
+3. Existing rotated files are shifted: `kall.log.2` becomes `kall.log.3`, `kall.log.1` becomes `kall.log.2`
+4. The current `kall.log` becomes `kall.log.1`
+5. A new empty `kall.log` is created for future writes
+6. Files beyond `KALL_LOG_KEEP_ROTATED` (default: 3) are deleted
+
+### Configuration
+
+Control rotation behavior in `kall.yml`:
+
+```yaml
+logging:
+  max_size_mb: 1       # Rotate when kall.log exceeds 1 MB
+  keep_rotated: 3      # Keep kall.log.1, kall.log.2, kall.log.3
+```
+
+### Invariants
+
+- **INV-LOG-03:** Log rotation never blocks startup. The rotation function catches all errors and continues silently.
+- Rotation uses `stat` for file size checks, with a macOS-compatible fallback (`stat -f%z` vs `stat -c%s`).
+
+## Common issues
+
+### Module fails with "backend adapter not found"
+
+The configured `menu_backend` in `kall.yml` does not match any installed backend. Check the value:
+
+```bash
+grep menu_backend ~/.config/kall/kall.yml
+```
+
+Valid backends: `rofi`, `wofi`, `fuzzel`, `tofi`, `dmenu`, `fzf`. Make sure the corresponding binary is installed.
+
+### "yq not found" errors
+
+kall requires `yq` (the Go-based YAML processor by Mike Farah) for configuration parsing. Install it:
+
+```bash
+# Arch
+pacman -S go-yq
+
+# macOS
+brew install yq
+
+# Other
+# Download from https://github.com/mikefarah/yq/releases
+```
+
+Do not confuse it with the Python-based `yq` wrapper around `jq`. kall requires the Go binary.
+
+### Theme colors not applying
+
+1. Check that your palette file is valid: `kall doctor`
+2. Regenerate backend themes: `./backends/generate-themes.sh`
+3. If using wallbash, verify ImageMagick is installed: `command -v convert`
+
+### Keybindings not working after inject
+
+1. Verify the keybindings were written: search for `>>> kall keybinds >>>` in your WM config
+2. Reload your WM config (e.g., `hyprctl reload` for Hyprland, `i3-msg reload` for i3)
+3. Check that the `kall` binary is in your PATH from the WM's perspective
+
+### Module shows no menu items
+
+1. Run in debug mode: `kall --debug <module>`
+2. Check `debug.log` for errors during menu construction
+3. Verify required tools are installed: `kall doctor`
+
+### Permission denied errors
+
+kall never requires root privileges for normal operation. If you see permission errors:
+
+1. Check file ownership: `ls -la ~/.config/kall/`
+2. Ensure XDG directories are writable
+3. If using the curl installer, do not pipe through `sudo bash`
+
+### High disk usage from logs
+
+If log files grow too large, reduce the rotation threshold or disable file logging:
+
+```yaml
+logging:
+  max_size_mb: 1
+  keep_rotated: 1
+```
+
+To clean up existing logs manually:
+
+```bash
+rm -f ~/.local/state/kall/logs/*.log*
+```

--- a/website/global.css
+++ b/website/global.css
@@ -1,3 +1,19 @@
 @import 'tailwindcss';
 @import 'fumadocs-ui/css/catppuccin.css';
 @import 'fumadocs-ui/css/preset.css';
+
+@keyframes hero-glow-shift {
+  0%, 100% {
+    filter: drop-shadow(0 0 30px rgba(203, 166, 247, 0.3));
+  }
+  33% {
+    filter: drop-shadow(0 0 40px rgba(137, 180, 250, 0.3));
+  }
+  66% {
+    filter: drop-shadow(0 0 35px rgba(245, 194, 231, 0.25));
+  }
+}
+
+.hero-glow {
+  animation: hero-glow-shift 6s ease-in-out infinite;
+}


### PR DESCRIPTION
Closes #65
Closes #67
Closes #68

## Summary

### Landing Page (8 components)
- Hero with install command + copy button
- Demo placeholder (terminal-style window)
- Feature grid (6 cards: modular, any backend, cross-platform, dynamic themes, pure bash, extensible)
- Module showcase grouped by category
- Theme preview with 6 palettes
- Social proof with GitHub badge
- Getting started CTA (repeated install command)
- Footer with navigation links

### User Docs (5 pages)
- keybindings.mdx (211 lines) — normalized format, WM translation, injection
- themes.mdx (255 lines) — 6 palettes, wallbash, custom palette guide
- troubleshooting.mdx (203 lines) — debug mode, logs, kall doctor
- faq.mdx (176 lines) — 7 questions fully answered
- modules.mdx (155 lines) — 26 module catalog table

### Module Author Docs (2 pages)
- authoring-guide.mdx (290 lines) — end-to-end module creation guide
- module-yml-spec.mdx (304 lines) — complete field reference with examples

## Still needed (separate PRs)
- User: getting-started.mdx, configuration.mdx (on another branch)
- Module authors: lib-api.mdx, testing-guide.mdx, best-practices.mdx
- Contributor: ci-cd.mdx, distribution.mdx (on PR #79 branch)