### PR TITLE
docs(docs/user): complete user documentation

### DIFF
--- a/website/content/user/configuration.mdx
+++ b/website/content/user/configuration.mdx
@@ -1,0 +1,260 @@
+---
+title: Configuration
+description: Complete reference for kall.yml — backends, modules, appearance, logging, and overrides.
+---
+
+All user configuration lives in a single file:
+
+```
+~/.config/kall/kall.yml
+```
+
+kall works out of the box with no configuration file. Every value has a built-in default. Create or edit `kall.yml` only when you want to change something.
+
+---
+
+## Full example
+
+```yaml
+# ~/.config/kall/kall.yml
+
+version: "2.0.0"
+menu_backend: rofi
+theme: catppuccin-mocha
+dynamic_theme: false
+launcher_style: style_1
+
+modules:
+  - power
+  - clipboard
+  - screenshot
+  - websearch
+  - bookmarks
+  - media
+  - zen-tabs
+  - tmux
+  - obsidian
+
+appearance:
+  managed: true
+  font: "JetBrainsMono Nerd Font 10"
+  icon_theme: "Adwaita"
+  border_radius: 8
+  border_width: 2
+  opacity: 0.95
+
+logging:
+  level: INFO
+  file: true
+  max_size_mb: 1
+  keep_rotated: 3
+
+custom_groups:
+  - name: favorites
+    layout: list
+    members: [power, clipboard, screenshot, websearch]
+
+module_overrides:
+  wallpaper:
+    layout_hints:
+      columns: 6
+      icon_size: medium
+  projects:
+    layout_hints:
+      preview:
+        fzf:
+          command: "eza --tree --level=3 --icons --git-ignore --color=always {}"
+          size: "70%"
+```
+
+---
+
+## Property reference
+
+### Top-level properties
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `version` | string | `"2.0.0"` | Config schema version. Used for migration. |
+| `menu_backend` | string | `rofi` | Active menu launcher. One of: `rofi`, `wofi`, `tofi`, `fuzzel`, `dmenu`, `fzf`. |
+| `theme` | string | `catppuccin-mocha` | Active color palette name. Must match a file in `themes/palettes/`. |
+| `dynamic_theme` | bool | `false` | Enable wallbash dynamic theming from wallpaper colors. |
+| `launcher_style` | string | `style_1` | Launcher window style. 12 windowed styles plus `launchpad` (fullscreen). |
+
+### modules
+
+An array of module names to enable. Only listed modules are available via `kall <module>`.
+
+```yaml
+modules:
+  - power
+  - clipboard
+  - screenshot
+  - websearch
+```
+
+Manage modules with the CLI instead of editing this list directly:
+
+```bash
+kall add emoji calculator
+kall remove zen-workspaces
+```
+
+### appearance
+
+Controls how kall styles its menu windows. Every appearance property supports three states:
+
+| State | Meaning | Example |
+|---|---|---|
+| **A value** | kall applies this value to all menu windows | `border_radius: 8` |
+| **`false`** | kall skips this property — your system (compositor, WM) handles it | `border_radius: false` |
+| **Absent** | kall uses its built-in default | _(omit the key entirely)_ |
+
+This three-state design lets you selectively hand control back to your system. For example, if your compositor already handles window opacity, set `opacity: false` so kall does not override it.
+
+#### appearance properties
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `managed` | bool | `true` | Master switch. Set to `false` to disable all kall styling — your system handles everything. |
+| `font` | string or `false` | `"JetBrainsMono Nerd Font 10"` | Font for menu text. Set to `false` to use system font. |
+| `icon_theme` | string or `false` | `"Adwaita"` | Icon theme for menu entries. Set to `false` to use system icon theme. |
+| `border_radius` | int or `false` | `8` | Corner radius in pixels. Set to `false` if your compositor handles rounding. |
+| `border_width` | int or `false` | `2` | Border width in pixels. Set to `false` to disable borders. |
+| `opacity` | float or `false` | `0.95` | Window opacity (0.0 to 1.0). Set to `false` if picom or Hyprland window rules handle opacity. |
+
+#### Examples
+
+Let kall handle everything (default):
+
+```yaml
+appearance:
+  managed: true
+  font: "JetBrainsMono Nerd Font 10"
+  border_radius: 8
+  opacity: 0.95
+```
+
+Let your system handle everything:
+
+```yaml
+appearance:
+  managed: false
+```
+
+Mixed — kall handles font and borders, system handles opacity and rounding:
+
+```yaml
+appearance:
+  font: "Iosevka Nerd Font 11"
+  border_width: 1
+  border_radius: false
+  opacity: false
+```
+
+### logging
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `level` | string | `INFO` | Minimum log level. One of: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`. |
+| `file` | bool | `true` | Write logs to `$XDG_STATE_HOME/kall/kall.log`. Set to `false` for stderr only. |
+| `max_size_mb` | int | `1` | Rotate the log file when it exceeds this size in megabytes. |
+| `keep_rotated` | int | `3` | Number of rotated log files to keep (`kall.log.1`, `kall.log.2`, etc.). |
+
+```yaml
+logging:
+  level: INFO
+  file: true
+  max_size_mb: 1
+  keep_rotated: 3
+```
+
+### custom_groups
+
+Define your own module groups that aggregate multiple modules into a single navigable menu.
+
+```yaml
+custom_groups:
+  - name: favorites
+    layout: list
+    members: [power, clipboard, screenshot, websearch]
+  - name: daily
+    layout: tabs
+    members: [obsidian, tmux, projects, websearch]
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `name` | string | Group name. Invoke with `kall <name>`. |
+| `layout` | string | Navigation style: `tabs`, `breadcrumbs`, `sections`, or `list`. |
+| `members` | array | List of module names to include. |
+
+### module_overrides
+
+Override layout hints for any module without editing module source files.
+
+```yaml
+module_overrides:
+  wallpaper:
+    layout_hints:
+      columns: 6
+      icon_size: medium
+  projects:
+    layout_hints:
+      preview:
+        fzf:
+          command: "eza --tree --level=3 --icons --git-ignore --color=always {}"
+          size: "70%"
+```
+
+Available layout hint properties:
+
+| Property | Type | Description |
+|---|---|---|
+| `columns` | int | Number of columns in grid layout. |
+| `icon_size` | string | Icon size: `small`, `medium`, or `large`. |
+| `show_icons` | bool | Whether to show icons in menu entries. |
+| `show_preview` | bool | Whether to show preview pane (fzf only). |
+| `orientation` | string | `horizontal` or `vertical`. |
+| `width` | string | Window width hint (e.g., `"80%"`). |
+| `lines` | int | Number of visible rows. |
+| `preview` | object | Backend-specific preview configuration. |
+
+---
+
+## Module configs
+
+Modules with user-configurable options store their config in separate files:
+
+```
+~/.config/kall/config/
+├── websearch.yml
+├── git-profiles.yml
+└── zen-workspaces.yml
+```
+
+Each module documents its own config options. These files are created automatically when you install a module with `kall add`.
+
+---
+
+## File locations
+
+| Path | Purpose |
+|---|---|
+| `~/.config/kall/kall.yml` | Main configuration |
+| `~/.config/kall/config/` | Per-module user configs |
+| `~/.config/kall/themes/` | Active theme files |
+| `~/.local/share/kall/` | Source installation (never edit) |
+| `$XDG_STATE_HOME/kall/` | Log files |
+
+---
+
+## Validation
+
+Validate your configuration at any time:
+
+```bash
+kall doctor
+```
+
+This checks `kall.yml` against the config schema, verifies all referenced modules exist, checks dependencies, and reports issues. kall also validates the config on every startup and falls back to built-in defaults for any invalid values.

--- a/website/content/user/faq.mdx
+++ b/website/content/user/faq.mdx
@@ -1,176 +1,147 @@
 ---
 title: FAQ
-description: Frequently asked questions about kall, its design, and compatibility.
+description: Frequently asked questions about kall — naming, architecture, backends, modules, and platform support.
 ---
 
 ## What does "kall" mean?
 
-"Kall" comes from the Scandinavian word for "call" or "summon." It reflects the tool's purpose: summoning menus, modules, and actions through a single command.
+Kall is Scandinavian for "call" or "summon." You summon your tools with a single command.
 
-## Why is kall written in bash?
+---
 
-Bash is universal on Linux and macOS. It requires no runtime, no compilation, and no dependency management beyond the shell itself. Since kall's primary job is orchestrating CLI tools (menu launchers, clipboard managers, screenshot tools, notification daemons), bash is the natural language for that domain. Every target system already has it.
+## Why bash?
 
-kall does require bash 4+ for associative arrays and other modern features. macOS ships bash 3.x, so Homebrew users need to install a newer version (`brew install bash`).
+Bash is universal. It is installed on every Linux distribution and macOS out of the box. Writing kall in bash means:
+
+- **No runtime dependencies.** No Python, no Node.js, no Ruby. Just bash and a few standard tools.
+- **Instant startup.** No interpreter warmup, no virtual environment activation.
+- **Easy to read and modify.** Any sysadmin or power user can understand and extend kall.
+
+External standalone tools like `jq`, `yq`, `playerctl`, and `chafa` are acceptable dependencies because they are compiled binaries that work across systems without requiring a runtime environment.
+
+---
 
 ## Does kall replace rofi?
 
-No. kall uses rofi (or any other supported launcher) as a backend. Rofi renders the menu UI; kall provides the module logic, theming, keybinding translation, and cross-platform abstraction on top of it. You can swap rofi for wofi, fzf, fuzzel, tofi, or dmenu without changing any module code.
+No. kall uses rofi (or any supported launcher) as one possible backend. rofi is the default, but it is not a hard dependency.
+
+kall is the layer above the menu launcher. It provides modules (power menu, clipboard manager, screenshot tool, etc.) and handles theming, keybindings, and platform abstraction. The menu launcher is just the rendering engine.
+
+Think of it this way: kall is the application, rofi is the display driver.
+
+---
 
 ## Can I use only some modules?
 
-Yes. kall is fully modular. Install only what you need:
+Yes. Install only the modules you need:
 
 ```bash
 kall add power clipboard screenshot
 ```
 
-During installation, pick the "minimal" preset (5 modules) or choose individual modules from the list. Unused modules are not loaded, not sourced, and have no runtime cost.
+Or pick a preset during installation:
+
+- **minimal** — 5 essential modules
+- **standard** — 15 commonly used modules
+- **full** — all 26 modules
+
+You can add and remove modules at any time:
+
+```bash
+kall add emoji calculator
+kall remove zen-workspaces
+kall list                     # See what is installed
+```
+
+---
 
 ## Can I switch menu backends?
 
-Yes. Change the `menu_backend` key in `kall.yml`:
+Yes. Change the `menu_backend` value in `kall.yml`:
 
 ```yaml
-menu_backend: fzf
+menu_backend: wofi
 ```
 
-Or from the command line:
+Supported backends: `rofi`, `wofi`, `tofi`, `fuzzel`, `dmenu`, `fzf`.
 
-```bash
-kall theme set-backend fzf
-```
+Every module works with every backend. Some features degrade gracefully when a backend lacks certain capabilities (for example, fzf supports preview panes but rofi does not, while rofi supports calculator mode but fzf does not). Modules detect capabilities at runtime and adapt automatically.
 
-All modules work with every backend. Layout hints (icons, columns, preview panes) degrade gracefully when the backend does not support them. For example, fzf supports preview pipelines but not icons; dmenu supports neither.
-
-Supported backends: `rofi`, `wofi`, `fuzzel`, `tofi`, `dmenu`, `fzf`.
+---
 
 ## Can I disable kall's styling?
 
-Yes. If you want your system theme, compositor, or WM to handle all visual appearance:
+Yes. kall ships its own defaults for font, border radius, opacity, icon theme, and border width. You can disable styling at three levels:
+
+**Disable all styling** — let your system handle everything:
 
 ```yaml
 appearance:
   managed: false
 ```
 
-This disables all appearance arguments kall passes to the menu backend. The launcher renders with its own default theme.
-
-You can also disable individual properties:
+**Disable individual properties** — set any property to `false`:
 
 ```yaml
 appearance:
-  managed: true
-  font: "JetBrainsMono Nerd Font 12"
-  icon_theme: false
-  border_radius: false
-  border_width: 2
-  opacity: false
+  font: "JetBrainsMono Nerd Font 10"   # kall handles font
+  border_radius: false                   # system handles rounding
+  opacity: false                         # picom/compositor handles opacity
 ```
 
-Any property set to `false` is skipped entirely -- kall does not pass that argument to the backend.
+**Use defaults** — omit properties entirely and kall applies its built-in defaults.
+
+See [Configuration](/user/configuration) for the full appearance reference.
+
+---
 
 ## What are the hard dependencies?
 
-kall has three hard dependencies that every installation requires:
+kall has only three framework-level dependencies:
 
-| Dependency | Purpose |
+| Dependency | Why |
 |---|---|
-| A menu launcher | Render menus. At least one of: rofi, wofi, fuzzel, tofi, dmenu, fzf |
-| `yq` | Parse YAML configuration and module manifests (Go-based, by Mike Farah) |
-| `jq` | Parse JSON output from system tools and APIs |
+| A menu launcher (rofi default) | Renders the menu UI — you choose which one |
+| `yq` | Parses module and config YAML files |
+| `jq` | Parses JSON from system tools |
 
-Everything else is per-module. Each module declares its own dependencies in `module.yml` under `requires.adapter_tools`. The `kall doctor` command shows which tools are missing for your installed modules.
+Everything else is per-module. When you install a module with `kall add`, it checks for required dependencies and offers to install them.
 
-Common per-module dependencies include:
+---
 
-| Tool | Used by | Session |
-|---|---|---|
-| `xclip` | clipboard, screenshot | X11 |
-| `wl-copy` / `wl-paste` | clipboard, screenshot | Wayland |
-| `grim` + `slurp` | screenshot | Wayland |
-| `maim` | screenshot | X11 |
-| `playerctl` | media | All |
-| `bluetoothctl` | bluetooth | Linux |
-| `systemctl` | systemd, power | Linux |
-| `ImageMagick` | wallbash (dynamic theming) | All |
+## Does it work on macOS?
 
-## Does kall work on macOS?
+Yes. kall supports macOS with some limitations:
 
-Yes, with limitations. kall detects macOS via `uname` and sets `KALL_OS=darwin` and `KALL_SESSION=darwin`. Platform-specific lib functions dispatch to macOS equivalents:
+**Fully supported modules** — launcher, power, clipboard, screenshot, wallpaper, websearch, calculator, emoji, glyph, media, git-profiles, tmux, projects, bookmarks, zen-tabs, zen-workspaces, obsidian, obsidian-search, weather, theme-selector, style-selector, keybindings (partial).
 
-| Function | macOS tool |
-|---|---|
-| `clipboard_copy` | `pbcopy` |
-| `clipboard_paste` | `pbpaste` |
-| `screenshot_full` | `screencapture` |
-| `screenshot_area` | `screencapture -s` |
-| `screenshot_window` | `screencapture -w` |
-| `open_url` | `open` |
-| `set_wallpaper` | `osascript` (Finder AppleScript) |
-| `notify` | `osascript` (notification center) |
+**Not available on macOS** — display (multi-monitor manager), bluetooth, systemd, notifications. These modules depend on Linux-specific subsystems.
 
-Some modules are unavailable on macOS because they depend on Linux-only subsystems:
+On macOS, kall uses `skhd` for keybinding injection and `pbcopy`/`pbpaste` for clipboard operations. The installer uses Homebrew for dependency management.
 
-- **display** -- requires `xrandr` or Wayland protocols for monitor management
-- **bluetooth** -- requires `bluetoothctl` (Linux BlueZ stack)
-- **systemd** -- requires `systemctl` (Linux init system)
-- **notifications** -- requires `notify-send` / libnotify
+---
 
-Each module declares its platform support in `module.yml`. The `kall list` command only shows modules compatible with your detected platform.
+## How do I write my own module?
 
-For keybindings on macOS, kall generates skhd syntax:
-
-```
-shift + cmd - e : kall power
-```
-
-## How do I update kall?
-
-If you installed via the curl installer or GitHub release:
-
-```bash
-kall update
-```
-
-If you installed via a package manager:
-
-```bash
-# AUR
-yay -Syu kall
-
-# Homebrew
-brew upgrade kall
-```
-
-## Can I create my own modules?
-
-Yes. See the [Module Authors](/docs/module-authors) section for a complete guide. The short version:
+Use the scaffolding command:
 
 ```bash
 kall create-module my-module
 ```
 
-This scaffolds a module directory with `module.yml`, an entry script, and a test file. Write your logic using kall's lib functions (`menu_launch`, `clipboard_copy`, `notify`, etc.) and submit a PR.
+This creates the standard module structure:
 
-## Where are logs stored?
+```
+modules/my-module/
+├── module.yml       # Metadata, deps, keybindings, layout hints
+└── my-module.sh     # Entry point script
+```
 
-Log files live in `$XDG_STATE_HOME/kall/logs/` (default: `~/.local/state/kall/logs/`):
+Key rules for module development:
 
-- **kall.log** -- INFO-level and above messages from normal operation
-- **debug.log** -- all log levels, only written when debug mode is active (`kall --debug`)
+- Modules call `lib/` functions only — never platform tools directly.
+- Every module must work on both X11 and Wayland (Linux).
+- Every module must work with every supported menu backend.
+- Every module needs a test file: `tests/test_my-module.bats`.
 
-Logs rotate automatically when `kall.log` exceeds 1 MB (configurable). See [Troubleshooting](/docs/user/troubleshooting) for details.
-
-## How do I report a bug?
-
-Open an issue on [GitHub](https://github.com/shaiknoorullah/kall/issues) using the bug report template. Include:
-
-1. Output of `kall doctor`
-2. Your `kall.yml` (remove any sensitive data)
-3. Relevant log entries from `~/.local/state/kall/logs/kall.log`
-4. If possible, debug output: `kall --debug <module> 2>debug-output.txt`
-
-## Does kall phone home or collect telemetry?
-
-No. kall makes no network requests except those explicitly initiated by modules (e.g., the websearch module opens a URL in your browser, the weather module queries wttr.in). There is no analytics, no crash reporting, and no update checking. The `kall update` command is the only network operation in the framework itself.
+See the [module authoring documentation](/module-authors) for the complete guide.

--- a/website/content/user/getting-started.mdx
+++ b/website/content/user/getting-started.mdx
@@ -1,0 +1,120 @@
+---
+title: Getting Started
+description: Install kall and run your first commands in under two minutes.
+---
+
+## Installation
+
+The fastest way to install kall is with the one-line installer:
+
+```bash
+curl -fsSL kall.sh/install | bash
+```
+
+The installer automatically detects your OS, display server, window manager, package manager, and shell. It then walks you through an interactive setup wizard.
+
+### What the installer does
+
+1. **Detects your system** — OS, display server (X11/Wayland), window manager, package manager, shell.
+2. **Installs framework dependencies** — a menu launcher (you choose which), `yq`, and `jq`.
+3. **Lets you pick modules** — grouped by category, with presets for quick selection.
+4. **Lets you pick a theme** — palette and launcher style, with optional wallbash.
+5. **Resolves dependencies** — aggregates deps from your selected modules, shows what is missing, asks before installing.
+6. **Installs and configures** — clones the repo, generates `kall.yml`, generates theme files, symlinks the CLI.
+7. **Prints a summary** — what was installed, suggested keybindings for your WM, and `kall doctor` results.
+
+The installer never runs as root. It uses `sudo` only for package installation and always asks before each `sudo` invocation.
+
+### Non-interactive install
+
+For scripted or headless setups, pass flags directly:
+
+```bash
+curl -fsSL kall.sh/install | bash -s -- \
+  --non-interactive \
+  --preset standard \
+  --backend rofi \
+  --theme catppuccin-mocha \
+  --style style_1 \
+  --no-wallbash
+```
+
+Available presets: `minimal` (5 modules), `standard` (15 modules), `full` (all 26 modules).
+
+### Post-install setup
+
+If you installed kall through a package manager (AUR, Homebrew), run the interactive setup wizard manually:
+
+```bash
+kall setup
+```
+
+This walks you through module selection, theme picking, and keybinding injection — the same wizard the curl installer runs.
+
+---
+
+## First run
+
+After installation, try these commands to see kall in action:
+
+```bash
+kall power          # Power menu — shutdown, reboot, lock, suspend, logout
+kall clipboard      # Clipboard history with search
+kall screenshot     # Screenshot capture — full, area, or window
+kall websearch      # Web search with autocomplete and bang syntax
+```
+
+Each command opens a menu using your configured backend (rofi by default). Select an option and kall handles the rest.
+
+### Running modules
+
+Every module is invoked as `kall <module>`:
+
+```bash
+kall launcher       # App launcher
+kall emoji          # Emoji picker
+kall bluetooth      # Bluetooth device manager
+kall tmux           # Tmux session manager
+```
+
+### Module management
+
+Add or remove modules at any time:
+
+```bash
+kall add emoji calculator systemd     # Install modules and their deps
+kall remove zen-workspaces            # Remove a module
+kall list                             # Show installed modules
+kall list --available                 # Show all modules for your platform
+```
+
+### Health check
+
+Run the built-in diagnostic tool to verify everything is working:
+
+```bash
+kall doctor
+```
+
+This checks dependencies, validates your configuration, and reports any issues.
+
+---
+
+## Keybinding injection
+
+kall can inject keybindings into your window manager config automatically:
+
+```bash
+kall keybinds inject    # Auto-detect WM and inject keybindings
+kall keybinds show      # Preview keybindings for your WM
+```
+
+The installer wizard offers to do this during setup. See [Keybindings](/user/keybindings) for full details.
+
+---
+
+## Next steps
+
+- [Configuration](/user/configuration) — full `kall.yml` reference
+- [Modules](/user/modules) — browse all 26 available modules
+- [Themes](/user/themes) — palettes, wallbash, and custom themes

--- a/website/content/user/keybindings.mdx
+++ b/website/content/user/keybindings.mdx
@@ -1,13 +1,15 @@
 ---
 title: Keybindings
-description: Bind kall modules to keyboard shortcuts across window managers using the normalized keybinding system.
+description: Normalized keybinding format, WM translation, injection, and export for all supported window managers.
 ---
 
-kall uses a normalized keybinding format that translates to the native syntax of each supported window manager. You define bindings once in `module.yml` using a generic modifier + key format, and kall generates WM-specific configuration lines that can be injected into your WM config file.
+kall uses a normalized keybinding format that translates automatically into the syntax required by each supported window manager. You define keybindings once — kall handles the rest.
 
-## Keybinding format
+---
 
-Keybindings are declared in each module's `module.yml` under the `keybinding` key:
+## Normalized format
+
+Every module declares its keybinding in `module.yml` using a simple, WM-agnostic format:
 
 ```yaml
 keybinding:
@@ -15,197 +17,168 @@ keybinding:
   key: e
 ```
 
-The `mods` array accepts these normalized modifier names:
+This means "mod + shift + e" regardless of which window manager you use.
 
-| Modifier | Meaning |
+### Available modifiers
+
+| Modifier | Description |
 |---|---|
-| `mod` / `super` | The Super/Windows/Command key |
+| `mod` | The WM's primary modifier (`$mod` in i3/sway, `$mainMod` in Hyprland) |
 | `shift` | Shift key |
 | `ctrl` | Control key |
-| `alt` | Alt/Option key |
+| `alt` | Alt/Meta key |
+| `super` | Super/Windows/Command key |
 
-The `key` field is the literal key name (e.g., `e`, `Return`, `1`, `space`).
+The `key` field is a single key in lowercase (e.g., `e`, `space`, `1`, `Return`).
 
-## Managing keybindings
+---
 
-kall provides four subcommands for keybinding management:
-
-### Show keybindings
-
-Display all module keybindings translated for the detected window manager:
+## CLI commands
 
 ```bash
-kall keybinds show
+kall keybinds show                # Print keybindings for your detected WM
+kall keybinds export hyprland     # Print in Hyprland format to stdout
+kall keybinds inject              # Auto-detect WM and inject into config
+kall keybinds inject --wm sway    # Inject for a specific WM
+kall keybinds remove              # Remove injected kall block from WM config
 ```
 
-Output example on Hyprland:
+---
 
-```
-power:       bind = $mainMod SHIFT, E, exec, kall power
-clipboard:   bind = $mainMod, V, exec, kall clipboard
-screenshot:  bind = $mainMod, PRINT, exec, kall screenshot
-```
+## Supported window managers
 
-### Inject keybindings
+| WM | Config file | Injection method |
+|---|---|---|
+| Hyprland | `~/.config/hypr/hyprland.conf` | Append block |
+| i3 | `~/.config/i3/config` | Append block |
+| sway | `~/.config/sway/config` | Append block |
+| bspwm (sxhkd) | `~/.config/sxhkd/sxhkdrc` | Append block |
+| awesome | `~/.config/awesome/rc.lua` | Append block |
+| skhd (macOS) | `~/.config/skhd/skhdrc` | Append block |
 
-Write keybinding lines into your WM configuration file:
+If your WM is not in this list, `kall keybinds show` prints the keybindings in a readable format so you can add them manually.
+
+---
+
+## Translation examples
+
+Given a module with `mods: [mod, shift], key: e` bound to `kall power`, here is what kall generates for each WM:
+
+### Hyprland
 
 ```bash
-kall keybinds inject
-```
-
-Injected bindings are wrapped in block markers so kall can locate and update them later:
-
-```
-# >>> kall keybinds >>>
 bind = $mainMod SHIFT, E, exec, kall power
-bind = $mainMod, V, exec, kall clipboard
-bind = $mainMod, PRINT, exec, kall screenshot
+```
+
+Modifiers are uppercased and space-separated. The key is uppercased. The command follows `exec,`.
+
+### i3 / sway
+
+```bash
+bindsym $mod+Shift+e exec kall power
+```
+
+Modifiers are joined with `+`. `mod` becomes `$mod`, `alt` becomes `Mod1`.
+
+### bspwm (sxhkd)
+
+```bash
+super + shift + e
+	kall power
+```
+
+Modifiers are space-separated with `+`. The command is indented on the next line.
+
+### awesome
+
+```bash
+awful.key({ modkey, "Shift" }, "e", function() awful.spawn("kall power") end)
+```
+
+Modifiers are Lua table entries. `mod` becomes `modkey`, others are quoted strings.
+
+### skhd (macOS)
+
+```bash
+shift + cmd - e : kall power
+```
+
+`mod`/`super` becomes `cmd`. Modifiers are `+` separated before the key, with ` - ` before the key and ` : ` before the command.
+
+---
+
+## More translation examples
+
+| Normalized | Hyprland | i3/sway |
+|---|---|---|
+| `mods: [mod], key: space` | `bind = $mainMod, SPACE, exec, kall launcher` | `bindsym $mod+space exec kall launcher` |
+| `mods: [mod, ctrl], key: b` | `bind = $mainMod CTRL, B, exec, kall bluetooth` | `bindsym $mod+Ctrl+b exec kall bluetooth` |
+| `mods: [mod, shift], key: s` | `bind = $mainMod SHIFT, S, exec, kall screenshot` | `bindsym $mod+Shift+s exec kall screenshot` |
+
+---
+
+## Injection behavior
+
+When you run `kall keybinds inject`, kall:
+
+1. Detects your window manager (or uses the `--wm` flag).
+2. Locates the WM config file.
+3. Shows the keybindings it will inject and asks for confirmation.
+4. Writes the keybindings inside a clearly marked block.
+
+The injected block looks like this (Hyprland example):
+
+```bash
+# >>> kall keybinds >>>
+bind = $mainMod, SPACE, exec, kall launcher
+bind = $mainMod SHIFT, E, exec, kall power
+bind = $mainMod SHIFT, S, exec, kall screenshot
 # <<< kall keybinds <<<
 ```
 
-The block markers (`# >>> kall keybinds >>>` and `# <<< kall keybinds <<<`) are preserved across re-injections. Running `inject` again replaces the block contents with the current set of module keybindings.
+### Idempotent injection
 
-### Export keybindings
+Running `kall keybinds inject` again replaces the existing block. It never duplicates entries. This means you can safely re-run injection after adding or removing modules.
 
-Print keybinding lines to stdout without modifying any file:
-
-```bash
-kall keybinds export
-```
-
-This is useful for manual pasting or piping into other tools.
-
-### Remove keybindings
-
-Remove the kall keybinding block from your WM configuration:
+### Removing keybindings
 
 ```bash
 kall keybinds remove
 ```
 
-This deletes everything between the block markers (inclusive), leaving the rest of your config untouched.
+This strips the marked block from your WM config file cleanly, leaving the rest of your config untouched.
 
-## Supported window managers
+### Installer integration
 
-kall translates keybindings for six window managers and compositors. The translation is handled by `_translate_keybind()` in `lib/keybinds.sh`. Given the example binding `mods: [mod, shift]`, `key: e`, `command: kall power`, each WM produces:
+The installer wizard (step 7) offers to run `kall keybinds inject` automatically after installation. You can always do it later with `kall keybinds inject`.
 
-### Hyprland
+---
 
-```ini
-bind = $mainMod SHIFT, E, exec, kall power
-```
+## Custom keybindings
 
-Config file: `~/.config/hypr/hyprland.conf`
-
-Modifiers are translated to Hyprland's format: `mod`/`super` becomes `$mainMod`, keys are uppercased, and the command is prefixed with `exec,`.
-
-### i3
-
-```ini
-bindsym $mod+Shift+e exec kall power
-```
-
-Config file: `~/.config/i3/config`
-
-Modifiers are joined with `+`: `mod`/`super` becomes `$mod`, `shift` becomes `Shift`, `alt` becomes `Mod1`. The key follows directly after.
-
-### sway
-
-```ini
-bindsym $mod+Shift+e exec kall power
-```
-
-Config file: `~/.config/sway/config`
-
-Sway uses the same syntax as i3. The translation function handles both identically.
-
-### bspwm (sxhkd)
-
-```
-super + shift + e
-	kall power
-```
-
-Config file: `~/.config/sxhkd/sxhkdrc`
-
-bspwm uses sxhkd for keybindings. Modifiers are space-separated with ` + ` between them, and the command is indented on the next line with a tab.
-
-### awesome
-
-```lua
-awful.key({ modkey, "Shift" }, "e", function() awful.spawn("kall power") end)
-```
-
-Config file: `~/.config/awesome/rc.lua`
-
-Modifiers are listed in a Lua table: `mod`/`super` becomes `modkey`, others are quoted strings. The command is wrapped in `awful.spawn()`.
-
-### skhd (macOS)
-
-```
-shift + cmd - e : kall power
-```
-
-Config file: `~/.config/skhd/skhdrc`
-
-macOS uses skhd for keyboard shortcuts. `mod`/`super` becomes `cmd`, modifiers use ` + ` separators, a ` - ` precedes the key, and ` : ` separates the key from the command.
-
-## Translation details
-
-The `_translate_keybind` function in `lib/keybinds.sh` accepts four arguments:
-
-```bash
-_translate_keybind WM MODS_CSV KEY COMMAND
-```
-
-- **WM** -- one of: `hyprland`, `i3`, `sway`, `bspwm`, `awesome`, `skhd`
-- **MODS_CSV** -- comma-separated modifiers: `mod,shift` or `mod`
-- **KEY** -- the key to bind: `e`, `Return`, `1`, etc.
-- **COMMAND** -- the full command: `kall power`
-
-For unrecognized window managers, the function outputs a comment:
-
-```bash
-# kall power (bind mod,shift + e)
-```
-
-## Example module keybindings
-
-Here are typical keybindings across several modules:
-
-| Module | Mods | Key | What it does |
-|---|---|---|---|
-| power | mod, shift | e | Open the power menu |
-| clipboard | mod | v | Open clipboard history |
-| screenshot | mod | Print | Open the screenshot menu |
-| wallpaper | mod, shift | w | Open the wallpaper browser |
-| websearch | mod | s | Open web search |
-| emoji | mod | period | Open the emoji picker |
-
-Each module ships its own default keybinding in `module.yml`. Users can override these defaults per-module in `kall.yml`:
+Module keybindings are defined by module authors in `module.yml`. Groups can also have keybindings:
 
 ```yaml
-modules:
+# modules/groups/system.yml
+keybinding:
+  mods: [mod, shift]
+  key: s
+```
+
+To override a module's default keybinding, use `module_overrides` in `kall.yml`:
+
+```yaml
+module_overrides:
   power:
     keybinding:
       mods: [mod, ctrl]
-      key: q
+      key: p
 ```
 
-## Multiple WMs
+After changing keybindings, re-run `kall keybinds inject` to update your WM config.
 
-If you use different WMs on different machines (e.g., Hyprland at home, i3 at work), kall auto-detects the active WM via `XDG_CURRENT_DESKTOP` and translates keybindings accordingly. The normalized format in `module.yml` stays the same -- only the generated output changes.
+---
 
-## Manual configuration
+## Adding support for a new WM
 
-You are not required to use `kall keybinds inject`. You can copy the output of `kall keybinds export` and paste it into your WM config manually. The `export` command is a read-only operation that makes no changes to your system.
-
-For WMs not in the supported list, `kall keybinds export` prints a commented format that documents the intended binding:
-
-```bash
-# kall power (bind mod,shift + e)
-# kall clipboard (bind mod + v)
-```
-
-You can then translate these comments to your WM's native syntax.
+The translation logic lives in `lib/keybinds.sh`. Adding support for a new WM requires only adding a translator function — no changes to `module.yml` files or any module code. See the [module authoring documentation](/module-authors) for details.

--- a/website/content/user/modules.mdx
+++ b/website/content/user/modules.mdx
@@ -1,155 +1,138 @@
 ---
 title: Modules
-description: Catalog of all 26 kall modules with platform support and categories.
+description: Catalog of all 26 kall modules — descriptions, platform support, and categories.
 ---
 
-## Module catalog
+kall ships with 26 modules organized into six categories. Each module is a self-contained feature you invoke with `kall <module>`.
 
-kall ships 26 modules at launch, organized by category. Platform support indicates where each module works:
-
-- **X11** -- Linux with X11 display server
-- **Wayland** -- Linux with Wayland display server
-- **macOS** -- macOS (with skhd/yabai or standalone)
-
-### Core -- Launchers and navigation
-
-| Module | Description | X11 | Wayland | macOS |
-|---|---|:---:|:---:|:---:|
-| launcher | App launcher (drun, run, window, filebrowser) | Y | Y | Y |
-| style-selector | Visual launcher style switcher (12 styles) | Y | Y | Y |
-| keybindings | WM keybinding cheat sheet viewer | Y | Y | ~ |
-
-### System -- Hardware, display, power
-
-| Module | Description | X11 | Wayland | macOS |
-|---|---|:---:|:---:|:---:|
-| power | Shutdown, reboot, lock, suspend, logout | Y | Y | Y |
-| screenshot | Full, area, window capture + clipboard + OCR | Y | Y | Y |
-| clipboard | History, favorites, image preview, OCR scan | Y | Y | Y |
-| display | Multi-monitor layout manager | Y | Y | -- |
-| wallpaper | Category browser + setter + dynamic theme trigger | Y | Y | Y |
-| bluetooth | Scan, pair, connect, trust devices | Y | Y | -- |
-| systemd | Service manager (start, stop, enable, disable) | Y | Y | -- |
-
-### Productivity -- Search, calculate, pick
-
-| Module | Description | X11 | Wayland | macOS |
-|---|---|:---:|:---:|:---:|
-| websearch | Search with autocomplete + bang syntax | Y | Y | Y |
-| calculator | Calculator mode | Y | Y | Y |
-| emoji | Emoji picker with recents + grid/list | Y | Y | Y |
-| glyph | Nerd Font glyph picker | Y | Y | Y |
-| media | Media player controls (play, pause, next, prev) | Y | Y | Y |
-
-### Developer -- Git, tmux, projects
-
-| Module | Description | X11 | Wayland | macOS |
-|---|---|:---:|:---:|:---:|
-| git-profiles | Switch git user.name/email per project | Y | Y | Y |
-| tmux | Tmux session manager | Y | Y | Y |
-| projects | Project directory launcher (editor + terminal) | Y | Y | Y |
-
-### Browser -- Zen, bookmarks, search
-
-| Module | Description | X11 | Wayland | macOS |
-|---|---|:---:|:---:|:---:|
-| bookmarks | Browser bookmarks viewer (Firefox, Chrome, Zen) | Y | Y | Y |
-| zen-tabs | Fuzzy tab search with favicon preview | Y | Y | Y |
-| zen-workspaces | Domain-based tab grouping + dedup | Y | Y | Y |
-
-### Notes -- Obsidian
-
-| Module | Description | X11 | Wayland | macOS |
-|---|---|:---:|:---:|:---:|
-| obsidian | Quick actions (new note, daily, open vault) | Y | Y | Y |
-| obsidian-search | Full-text note search with preview | Y | Y | Y |
-
-### Additional modules
-
-| Module | Description | X11 | Wayland | macOS |
-|---|---|:---:|:---:|:---:|
-| weather | Weather display (wttr.in API) | Y | Y | Y |
-| notifications | Notification history viewer | Y | Y | -- |
-| theme-selector | Theme/palette browser with preview | Y | Y | Y |
-
-**Legend:** Y = supported, ~ = partial support, -- = not available
-
-## Managing modules
+## Module management
 
 ```bash
-# Install modules
-kall add emoji calculator tmux
-
-# Remove a module
-kall remove zen-workspaces
-
-# List installed modules
-kall list
-
-# List all available modules for your platform
-kall list --available
+kall add power clipboard screenshot    # Install modules and their deps
+kall remove zen-workspaces             # Remove a module
+kall list                              # Show installed modules
+kall list --available                  # Show all modules for your platform
 ```
 
-When you run `kall add`, kall reads the module's `module.yml`, checks platform compatibility, installs any missing dependencies via your system's package manager, adds the module to your `kall.yml`, and copies any user-editable config files.
+## Platform support
+
+| Symbol | Meaning |
+|---|---|
+| ✓ | Fully supported |
+| ~ | Partial support (some features unavailable) |
+| ✗ | Not available on this platform |
+
+---
+
+## Core — Launchers and Navigation
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| `launcher` | App launcher (drun, run, window, filebrowser) | ✓ | ✓ | ✓ |
+| `style-selector` | Visual launcher style switcher (12 styles) | ✓ | ✓ | ✓ |
+| `keybindings` | WM keybinding cheat sheet viewer | ✓ | ✓ | ~ |
+
+---
+
+## System — Hardware, Display, Power
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| `power` | Shutdown, reboot, lock, suspend, logout | ✓ | ✓ | ✓ |
+| `screenshot` | Full, area, window capture + clipboard + OCR | ✓ | ✓ | ✓ |
+| `clipboard` | History, favorites, image preview, OCR scan | ✓ | ✓ | ✓ |
+| `display` | Multi-monitor layout manager | ✓ | ✓ | ✗ |
+| `wallpaper` | Category browser + setter + dynamic theme trigger | ✓ | ✓ | ✓ |
+| `bluetooth` | Scan, pair, connect, trust devices | ✓ | ✓ | ✗ |
+| `systemd` | Service manager (start, stop, enable, disable) | ✓ | ✓ | ✗ |
+
+---
+
+## Productivity — Search, Calculate, Pick
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| `websearch` | Search with autocomplete + bang syntax | ✓ | ✓ | ✓ |
+| `calculator` | Calculator mode | ✓ | ✓ | ✓ |
+| `emoji` | Emoji picker with recents + grid/list | ✓ | ✓ | ✓ |
+| `glyph` | Nerd Font glyph picker | ✓ | ✓ | ✓ |
+| `media` | Media player controls (play, pause, next, prev) | ✓ | ✓ | ✓ |
+
+---
+
+## Developer — Git, Tmux, Projects
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| `git-profiles` | Switch git user.name/email per project | ✓ | ✓ | ✓ |
+| `tmux` | Tmux session manager | ✓ | ✓ | ✓ |
+| `projects` | Project directory launcher (editor + terminal) | ✓ | ✓ | ✓ |
+
+---
+
+## Browser — Zen, Bookmarks, Search
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| `bookmarks` | Browser bookmarks viewer (Firefox, Chrome, Zen) | ✓ | ✓ | ✓ |
+| `zen-tabs` | Fuzzy tab search with favicon preview | ✓ | ✓ | ✓ |
+| `zen-workspaces` | Domain-based tab grouping + dedup | ✓ | ✓ | ✓ |
+
+---
+
+## Notes — Obsidian
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| `obsidian` | Quick actions (new note, daily, open vault) | ✓ | ✓ | ✓ |
+| `obsidian-search` | Full-text note search with preview | ✓ | ✓ | ✓ |
+
+---
+
+## Other
+
+| Module | Description | X11 | Wayland | macOS |
+|---|---|:---:|:---:|:---:|
+| `weather` | Weather display (wttr.in API) | ✓ | ✓ | ✓ |
+| `notifications` | Notification history viewer | ✓ | ✓ | ✗ |
+| `theme-selector` | Theme/palette browser with preview | ✓ | ✓ | ✓ |
+
+---
 
 ## Module groups
 
-Groups aggregate multiple modules into a single navigable menu. kall ships five groups:
+Groups aggregate multiple modules into a single navigable menu. kall ships five built-in groups:
 
 | Group | Members |
 |---|---|
-| system | power, display, bluetooth, systemd |
-| productivity | websearch, calculator, emoji, glyph, media |
-| developer | git-profiles, tmux, projects |
-| browser | bookmarks, zen-tabs, zen-workspaces |
-| notes | obsidian, obsidian-search |
+| `system` | power, display, bluetooth, systemd |
+| `productivity` | websearch, calculator, emoji, glyph, media |
+| `developer` | git-profiles, tmux, projects |
+| `browser` | bookmarks, zen-tabs, zen-workspaces |
+| `notes` | obsidian, obsidian-search |
+
+Use groups with:
 
 ```bash
-# Open a group
-kall system
-
-# Jump to a specific module within a group
-kall system power
+kall system              # Open the system group menu
+kall system power        # Jump directly to power within the group
 ```
 
-You can define custom groups in your `kall.yml`. See [Configuration](/docs/user/configuration) for details.
+You can also define custom groups in `kall.yml`. See [Configuration](/user/configuration) for details.
 
-## Module structure
+---
 
-Every module lives in its own directory under `modules/` and contains:
+## Backend compatibility
 
-```
-modules/<name>/
-  module.yml        # Module manifest (required)
-  <name>.sh         # Entry script (required)
-  assets/           # Icons, preview scripts (optional)
-```
+Every module works with every supported menu backend. Some features degrade gracefully when a backend lacks certain capabilities:
 
-The `module.yml` manifest declares metadata, platform compatibility, dependencies, default keybinding, and layout hints. See the [Module YAML Spec](/docs/module-authors/module-yml-spec) for a full field reference.
+| Capability | rofi | wofi | fuzzel | tofi | dmenu | fzf |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Icons | ✓ | ✓ | ✓ | ✗ | ✗ | ~ |
+| Markup | ✓ | ✗ | ✗ | ✗ | ✗ | ~ |
+| Blocks (live input) | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ |
+| Calculator mode | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| App launching | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| Preview pane | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
 
-## Dependencies
-
-Modules declare two kinds of dependencies in `module.yml`:
-
-### Lib dependencies
-
-The `requires.lib` array lists kall library modules needed at runtime:
-
-```yaml
-requires:
-  lib: [platform, menu, notify]
-```
-
-### Adapter tool dependencies
-
-The `requires.adapter_tools` object maps session types to required system tools:
-
-```yaml
-requires:
-  adapter_tools:
-    x11: [xclip, maim]
-    wayland: [wl-copy, grim, slurp]
-    darwin: [pbcopy]
-```
-
-The `kall doctor` command checks that all tools required by installed modules are present on the system.
+Modules query backend capabilities at runtime and adapt automatically. A module will never crash because of a missing backend feature — it falls back to a simpler interface.

--- a/website/content/user/themes.mdx
+++ b/website/content/user/themes.mdx
@@ -1,138 +1,77 @@
 ---
 title: Themes
-description: Color palettes, dynamic wallbash theming, and custom palette creation.
+description: Color palettes, dynamic wallbash theming, custom palettes, and theme generation across backends.
 ---
 
-kall ships six curated color palettes and supports dynamic color extraction from your wallpaper. Palettes define eight canonical color slots that map to semantic roles in every menu backend. This page covers the built-in palettes, theme management commands, wallbash dynamic theming, and how to create your own palette.
+kall ships six curated color palettes and supports dynamic wallpaper-based theming. One palette definition generates theme files for every supported backend automatically.
 
-## Built-in palettes
-
-Six palettes are included in `themes/palettes/`:
-
-### Catppuccin Mocha
-
-A warm, pastel dark theme from the Catppuccin project.
-
-| Color slot | Hex | Role |
-|---|---|---|
-| `main_bg` | `#1E1E2E` | Primary background |
-| `main_fg` | `#CDD6F4` | Primary foreground |
-| `main_br` | `#CBA6F7` | Border / accent (mauve) |
-| `main_ex` | `#F5E0DC` | Extra accent (rosewater) |
-| `select_bg` | `#B4BEFE` | Selected item background (lavender) |
-| `select_fg` | `#1E1E2E` | Selected item foreground |
-| `urgent_bg` | `#F38BA8` | Urgent background (red) |
-| `urgent_fg` | `#1E1E2E` | Urgent foreground |
-
-### Dracula
-
-The classic Dracula dark palette.
-
-| Color slot | Hex | Role |
-|---|---|---|
-| `main_bg` | `#282A36` | Primary background |
-| `main_fg` | `#F8F8F2` | Primary foreground |
-| `main_br` | `#BD93F9` | Border / accent (purple) |
-| `main_ex` | `#FF79C6` | Extra accent (pink) |
-| `select_bg` | `#44475A` | Selected item background |
-| `select_fg` | `#F8F8F2` | Selected item foreground |
-| `urgent_bg` | `#FF5555` | Urgent background (red) |
-| `urgent_fg` | `#F8F8F2` | Urgent foreground |
-
-### Nord
-
-Arctic, north-bluish palette by Arctic Ice Studio.
-
-| Color slot | Hex | Role |
-|---|---|---|
-| `main_bg` | `#2E3440` | Primary background (Polar Night) |
-| `main_fg` | `#ECEFF4` | Primary foreground (Snow Storm) |
-| `main_br` | `#88C0D0` | Border / accent (Frost) |
-| `main_ex` | `#81A1C1` | Extra accent (Frost) |
-| `select_bg` | `#4C566A` | Selected item background |
-| `select_fg` | `#ECEFF4` | Selected item foreground |
-| `urgent_bg` | `#BF616A` | Urgent background (Aurora red) |
-| `urgent_fg` | `#ECEFF4` | Urgent foreground |
-
-### Gruvbox
-
-Retro groove palette by morhetz.
-
-| Color slot | Hex | Role |
-|---|---|---|
-| `main_bg` | `#282828` | Primary background (dark0) |
-| `main_fg` | `#EBDBB2` | Primary foreground (light1) |
-| `main_br` | `#D79921` | Border / accent (yellow) |
-| `main_ex` | `#458588` | Extra accent (blue) |
-| `select_bg` | `#504945` | Selected item background (dark2) |
-| `select_fg` | `#EBDBB2` | Selected item foreground |
-| `urgent_bg` | `#CC241D` | Urgent background (red) |
-| `urgent_fg` | `#EBDBB2` | Urgent foreground |
-
-### Tokyo Night
-
-Dark theme inspired by Tokyo city lights, by enkia.
-
-| Color slot | Hex | Role |
-|---|---|---|
-| `main_bg` | `#1A1B26` | Primary background |
-| `main_fg` | `#C0CAF5` | Primary foreground |
-| `main_br` | `#7AA2F7` | Border / accent (blue) |
-| `main_ex` | `#BB9AF7` | Extra accent (purple) |
-| `select_bg` | `#33467C` | Selected item background |
-| `select_fg` | `#C0CAF5` | Selected item foreground |
-| `urgent_bg` | `#F7768E` | Urgent background (red) |
-| `urgent_fg` | `#C0CAF5` | Urgent foreground |
-
-### Rose Pine
-
-Natural, muted palette from the Rose Pine project.
-
-| Color slot | Hex | Role |
-|---|---|---|
-| `main_bg` | `#191724` | Primary background (base) |
-| `main_fg` | `#E0DEF4` | Primary foreground (text) |
-| `main_br` | `#C4A7E7` | Border / accent (iris) |
-| `main_ex` | `#EBBCBA` | Extra accent (rose) |
-| `select_bg` | `#26233A` | Selected item background (overlay) |
-| `select_fg` | `#E0DEF4` | Selected item foreground |
-| `urgent_bg` | `#EB6F92` | Urgent background (love) |
-| `urgent_fg` | `#E0DEF4` | Urgent foreground |
+---
 
 ## Theme commands
 
-### Set active theme
+```bash
+kall theme list              # Show available palettes
+kall theme set dracula       # Switch to the Dracula palette
+kall theme wallbash on       # Enable dynamic wallpaper theming
+kall theme wallbash off      # Disable wallbash, use static palette
+kall style set style_5       # Change launcher window style
+```
 
-Switch to a different palette:
+---
+
+## Shipped palettes
+
+kall includes six palettes out of the box. Each palette defines eight core color variables used across all backends.
+
+### Color values
+
+| Palette | Background | Foreground | Border | Accent | Selection BG | Selection FG | Urgent BG | Urgent FG |
+|---|---|---|---|---|---|---|---|---|
+| **Catppuccin Mocha** | `#1E1E2E` | `#CDD6F4` | `#CBA6F7` | `#F5E0DC` | `#B4BEFE` | `#1E1E2E` | `#F38BA8` | `#1E1E2E` |
+| **Dracula** | `#282A36` | `#F8F8F2` | `#BD93F9` | `#FF79C6` | `#44475A` | `#F8F8F2` | `#FF5555` | `#F8F8F2` |
+| **Nord** | `#2E3440` | `#ECEFF4` | `#88C0D0` | `#81A1C1` | `#4C566A` | `#ECEFF4` | `#BF616A` | `#ECEFF4` |
+| **Gruvbox** | `#282828` | `#EBDBB2` | `#D79921` | `#458588` | `#504945` | `#EBDBB2` | `#CC241D` | `#EBDBB2` |
+| **Tokyo Night** | `#1A1B26` | `#C0CAF5` | `#7AA2F7` | `#BB9AF7` | `#33467C` | `#C0CAF5` | `#F7768E` | `#C0CAF5` |
+| **Rose Pine** | `#191724` | `#E0DEF4` | `#C4A7E7` | `#EBBCBA` | `#26233A` | `#E0DEF4` | `#EB6F92` | `#E0DEF4` |
+
+The palette color variables map to menu elements:
+
+| Variable | Purpose |
+|---|---|
+| `main_bg` | Menu window background |
+| `main_fg` | Default text color |
+| `main_br` | Window border color |
+| `main_ex` | Accent color for highlights |
+| `select_bg` | Selected item background |
+| `select_fg` | Selected item text |
+| `urgent_bg` | Urgent/destructive action background |
+| `urgent_fg` | Urgent/destructive action text |
+
+Some palettes (like Catppuccin Mocha) include extended color definitions beyond the core eight. These are available for modules and backends that support richer color schemes.
+
+---
+
+## Setting a theme
+
+In `kall.yml`:
+
+```yaml
+theme: catppuccin-mocha
+```
+
+Or via CLI:
 
 ```bash
-kall theme set dracula
+kall theme set nord
 ```
 
-This updates the `theme` key in `kall.yml` and regenerates backend-specific theme files.
+Both methods regenerate theme files for your active backend immediately.
 
-### List available palettes
-
-Show all palettes in `themes/palettes/`:
-
-```bash
-kall theme list
-```
-
-Output:
-
-```
-catppuccin-mocha
-dracula
-gruvbox
-nord
-rose-pine
-tokyo-night
-```
+---
 
 ## Dynamic wallbash
 
-Wallbash is an opt-in dynamic theming mode that extracts dominant colors from your current wallpaper instead of using a curated palette. It requires ImageMagick.
+Wallbash extracts dominant colors from your current wallpaper and generates a dynamic palette. Your menus automatically match your wallpaper.
 
 ### Enabling wallbash
 
@@ -140,116 +79,152 @@ Wallbash is an opt-in dynamic theming mode that extracts dominant colors from yo
 kall theme wallbash on
 ```
 
-This sets `dynamic_theme: true` in `kall.yml`. The next time any module runs, the theme engine calls `generate_wallbash()` instead of `load_theme()`.
+Or in `kall.yml`:
+
+```yaml
+dynamic_theme: true
+```
+
+### Requirements
+
+Wallbash requires **ImageMagick** (`convert`/`magick` command). If ImageMagick is not installed, wallbash falls back to your static palette silently.
 
 ### How it works
 
-The `generate_wallbash()` function in `lib/theme.sh` performs these steps:
-
-1. **Resize** the wallpaper image to 100x100 pixels (forced aspect ratio) for fast processing
-2. **Quantize** to 8 dominant colors using ImageMagick color reduction: `convert "$wallpaper" -resize 100x100! -colors 8 -unique-colors txt:-`
-3. **Extract** hex color codes from the output
-4. **Sort by luminance** using BT.601 coefficients (`R * 299 + G * 587 + B * 114`)
-5. **Map** sorted colors to `KALL_COLOR_*` variables (darkest to backgrounds, lightest to foregrounds)
-
-The luminance-based mapping:
-
-| Sort position | Variable | Role |
-|---|---|---|
-| 1 (darkest) | `KALL_COLOR_MAIN_BG` | Primary background |
-| 2 | `KALL_COLOR_SELECT_BG` | Selected item background |
-| 4 | `KALL_COLOR_URGENT_BG` | Urgent background |
-| 5 | `KALL_COLOR_MAIN_EX` | Extra accent |
-| 6 | `KALL_COLOR_MAIN_BR` | Border accent |
-| 7 | `KALL_COLOR_SELECT_FG` | Selected item foreground |
-| 8 (lightest) | `KALL_COLOR_MAIN_FG`, `KALL_COLOR_URGENT_FG` | Primary and urgent foreground |
+1. kall reads your current wallpaper path.
+2. ImageMagick extracts the dominant colors from the wallpaper image.
+3. kall generates a temporary palette YAML from those colors.
+4. The temporary palette feeds through the same theme generation pipeline as static palettes.
+5. Backend theme files are regenerated with the new colors.
 
 ### Fallback behavior
 
-Wallbash falls back to the static palette (the `theme` value in `kall.yml`) in three cases:
+Wallbash falls back to your static palette if any of these conditions are true:
 
-- The wallpaper file does not exist
-- ImageMagick (`convert`) is not installed
-- Color extraction produces fewer than 8 colors
+- ImageMagick is not installed
+- No wallpaper is set
+- Color extraction fails for any reason
 
-The fallback is automatic and silent except for a `WARN`-level log entry.
+The fallback is silent — kall logs a debug message but does not interrupt your workflow.
 
-### Disabling wallbash
+---
 
-```bash
-kall theme wallbash off
-```
+## Custom palettes
 
-This sets `dynamic_theme: false` and reverts to the static palette.
+Create your own palette by adding a YAML file to `themes/palettes/`.
 
-## Creating a custom palette
-
-### Step 1: Copy an existing palette
-
-Start from a palette close to what you want:
-
-```bash
-cp themes/palettes/catppuccin-mocha.yml themes/palettes/my-theme.yml
-```
-
-### Step 2: Edit the colors
-
-Open the file and replace the hex values. All eight color keys under `colors` are required:
+### Palette format
 
 ```yaml
-name: "My Custom Theme"
-author: "your-name"
+# themes/palettes/my-palette.yml
+
+name: "My Palette"
+author: "Your Name"
 
 colors:
-  main_bg: "#1a1b26"
-  main_fg: "#c0caf5"
-  main_br: "#7aa2f7"
-  main_ex: "#bb9af7"
-  select_bg: "#283457"
-  select_fg: "#c0caf5"
-  urgent_bg: "#f7768e"
-  urgent_fg: "#1a1b26"
+  main_bg: "#1a1a2e"
+  main_fg: "#eaeaea"
+  main_br: "#e94560"
+  main_ex: "#0f3460"
+  select_bg: "#533483"
+  select_fg: "#eaeaea"
+  urgent_bg: "#e94560"
+  urgent_fg: "#eaeaea"
+
+opacity:
+  bg: "e6"
 ```
 
-The schema (`schemas/palette.schema.yml`) enforces that `name`, `main_bg`, `main_fg`, `main_br`, `main_ex`, `select_bg`, and `select_fg` are all required. Omitting any key fails validation.
+### Required fields
 
-### Step 3: Validate
+Every palette must define the complete set of eight core color variables under `colors`:
 
-Run the doctor command to check schema compliance:
+- `main_bg`, `main_fg`, `main_br`, `main_ex`
+- `select_bg`, `select_fg`
+- `urgent_bg`, `urgent_fg`
+
+The `opacity.bg` field is optional and specifies the hex alpha value appended to background colors (e.g., `"e6"` for 90% opacity).
+
+### Using your palette
+
+After creating the file, it is immediately available:
 
 ```bash
-kall doctor
+kall theme list          # Your palette appears in the list
+kall theme set my-palette
 ```
 
-### Step 4: Generate backend themes
+No other changes are needed. The theme generator reads your palette and produces backend-specific theme files automatically.
 
-Regenerate theme files for all backends:
+---
 
-```bash
-./backends/generate-themes.sh
+## Theme generation across backends
+
+kall uses a single canonical palette YAML to generate theme files for every supported backend. You never write backend-specific theme code.
+
+The generation pipeline:
+
+```
+themes/palettes/catppuccin-mocha.yml
+        |
+        v
+backends/generate-themes.sh
+        |
+        +---> backends/rofi/themes/     (.rasi files)
+        +---> backends/wofi/themes/     (.css files)
+        +---> backends/tofi/themes/     (.ini files)
+        +---> backends/fuzzel/themes/   (.ini files)
+        +---> backends/dmenu/themes/    (.sh files — color args)
+        +---> backends/fzf/themes/      (.sh files — FZF_DEFAULT_OPTS)
 ```
 
-This reads your new palette and creates theme files in every backend's `themes/` directory (`.rasi` for rofi, `.css` for wofi, `.sh` for fzf and dmenu, `.ini` for tofi and fuzzel).
+Adding a new palette requires zero changes to any backend. The generator handles everything.
 
-### Step 5: Activate
+### What gets generated
 
-```bash
-kall theme set my-theme
-```
+Each backend receives theme files in its native format:
 
-## Color variable reference
-
-After theme loading (static or wallbash), these environment variables are available to all lib functions and backend adapters:
-
-| Variable | Palette key | Semantic role |
+| Backend | Format | Example |
 |---|---|---|
-| `KALL_COLOR_MAIN_BG` | `colors.main_bg` | Primary background |
-| `KALL_COLOR_MAIN_FG` | `colors.main_fg` | Primary foreground / text |
-| `KALL_COLOR_MAIN_BR` | `colors.main_br` | Border and accent color |
-| `KALL_COLOR_MAIN_EX` | `colors.main_ex` | Extra accent (highlights, badges) |
-| `KALL_COLOR_SELECT_BG` | `colors.select_bg` | Selected item background |
-| `KALL_COLOR_SELECT_FG` | `colors.select_fg` | Selected item foreground |
-| `KALL_COLOR_URGENT_BG` | `colors.urgent_bg` | Urgent / error background |
-| `KALL_COLOR_URGENT_FG` | `colors.urgent_fg` | Urgent / error foreground |
+| rofi | `.rasi` (CSS-like) | Color variables + layout templates |
+| wofi | `.css` | Standard CSS with color variables |
+| tofi | `.ini` | INI-style key=value pairs |
+| fuzzel | `.ini` | INI-style key=value pairs |
+| dmenu | `.sh` | Shell variables for `-nb`, `-nf`, `-sb`, `-sf` flags |
+| fzf | `.sh` | Shell variables for `--color` flag |
 
-Modules never read these variables directly. They declare layout hints and the backend adapter handles color application.
+---
+
+## Launcher styles
+
+kall supports 12 windowed launcher styles plus a fullscreen launchpad mode. Switch styles with:
+
+```bash
+kall style set style_5
+```
+
+Or use the visual style picker:
+
+```bash
+kall style-selector
+```
+
+Set a default in `kall.yml`:
+
+```yaml
+launcher_style: style_1
+```
+
+---
+
+## Theme in kall.yml
+
+The complete theme-related configuration:
+
+```yaml
+theme: catppuccin-mocha      # Active palette name
+dynamic_theme: false          # Enable/disable wallbash
+launcher_style: style_1       # Launcher window style
+```
+
+See [Configuration](/user/configuration) for the full `kall.yml` reference.

--- a/website/content/user/troubleshooting.mdx
+++ b/website/content/user/troubleshooting.mdx
@@ -1,203 +1,161 @@
 ---
 title: Troubleshooting
-description: Debug mode, log files, kall doctor, log rotation, and common issues.
+description: Debug mode, log files, kall doctor, and solutions for common issues.
 ---
-
-When something goes wrong with kall, the structured logging system and built-in diagnostic tool provide the information needed to identify and resolve problems.
 
 ## Debug mode
 
-Run any kall command with the `--debug` flag to enable verbose diagnostic output:
+kall has three ways to enable debug logging, from temporary to persistent:
+
+### Per-invocation flag
 
 ```bash
 kall --debug power
-kall --debug clipboard
-kall --debug doctor
 ```
 
-Debug mode sets the log level to `DEBUG` (numeric level 1), which causes two things:
+### Environment variable
 
-1. **All log messages** (including `TRACE` and `DEBUG`) are written to `debug.log`
-2. **Debug-level messages** include the source file and line number in the log format
-
-Normal log format (INFO and above):
-
-```
-[INFO] 2026-03-14 12:30:45  clipboard module loaded
+```bash
+KALL_LOG_LEVEL=DEBUG kall power
 ```
 
-Debug log format (DEBUG and TRACE):
+For the most detailed output, use `TRACE`:
 
-```
-[DEBUG] 2026-03-14 12:30:45.123 core.sh:42  OS=linux SESSION=wayland WM=hyprland BACKEND=rofi THEME=catppuccin-mocha
-[TRACE] 2026-03-14 12:30:45.124 platform.sh:51  clipboard_copy dispatching to wl-copy
+```bash
+KALL_LOG_LEVEL=TRACE kall clipboard
 ```
 
-The millisecond timestamp and `file:line` reference make it possible to trace exactly which code path executed.
+### Persistent in kall.yml
+
+```yaml
+logging:
+  level: DEBUG
+```
+
+When debug mode is active, kall outputs detailed diagnostic information including which adapter loaded, how the config was parsed, what tools were resolved, and the full function call chain.
+
+### Log levels
+
+| Level | What it shows |
+|---|---|
+| `TRACE` | Fine-grained execution flow — function entry/exit, variable values |
+| `DEBUG` | Diagnostic info — adapter loaded, config parsed, tool resolved |
+| `INFO` | Normal events — module started, theme applied (default) |
+| `WARN` | Recoverable issues — fallback used, optional dep missing |
+| `ERROR` | Failures that stop the current operation |
+| `FATAL` | Unrecoverable failures that stop kall entirely |
+
+---
 
 ## Log files
 
-kall writes logs to `$XDG_STATE_HOME/kall/logs/`, which defaults to `~/.local/state/kall/logs/`. Two log files are maintained:
+### User log
 
-### kall.log
-
-The primary log file. It receives messages at `INFO` level and above (`INFO`, `WARN`, `ERROR`, `FATAL`). Debug and trace messages are never written here, per invariant INV-LOG-02.
-
-```bash
-tail -50 ~/.local/state/kall/logs/kall.log
+```
+$XDG_STATE_HOME/kall/kall.log
 ```
 
-### debug.log
+This log captures `INFO` level and above during normal operation. It is automatically rotated when it exceeds 1 MB, keeping 3 rotated files (`kall.log.1`, `kall.log.2`, `kall.log.3`). Rotation is handled internally — no external logrotate dependency.
 
-The verbose log file. It receives all log levels (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`), but only when debug mode is active (log level set to `DEBUG` or `TRACE`).
+### Debug log
 
-```bash
-tail -100 ~/.local/state/kall/logs/debug.log
+```
+$XDG_STATE_HOME/kall/debug.log
 ```
 
-If you have never run kall in debug mode, `debug.log` may not exist.
+This log captures all levels (`TRACE` and above) but only when debug mode is active. It is automatically deleted after 24 hours of inactivity. Not rotated — capture what you need while debugging.
 
-### Log level hierarchy
+### Log format
 
-| Level | Numeric | Written to kall.log | Written to debug.log | Shown on stderr |
-|---|---|---|---|---|
-| `TRACE` | 0 | No | Yes (if debug active) | Only if log level is TRACE |
-| `DEBUG` | 1 | No | Yes (if debug active) | Only if log level is DEBUG or lower |
-| `INFO` | 2 | Yes | Yes (if debug active) | If log level is INFO or lower |
-| `WARN` | 3 | Yes | Yes (if debug active) | If log level is WARN or lower |
-| `ERROR` | 4 | Yes | Yes (if debug active) | Always |
-| `FATAL` | 5 | Yes | Yes (if debug active) | Always (then exits) |
+User-facing logs (INFO and above) are clean:
 
-`ERROR` and `FATAL` messages are always shown on stderr regardless of the configured log level.
+```
+[INFO]  2026-03-14 10:32:01  power: lock screen via hyprlock
+[WARN]  2026-03-14 10:32:02  clipboard: rofi-blocks not found, falling back to fzf
+[ERROR] 2026-03-14 10:32:03  screenshot: grim failed (exit 127) — is it installed?
+```
+
+Debug logs include full context:
+
+```
+[TRACE] 2026-03-14 10:32:01.423  core.sh:42       detect_session() -> wayland
+[DEBUG] 2026-03-14 10:32:01.425  menu.sh:18       loading backend adapter: backends/rofi/adapter.sh
+[DEBUG] 2026-03-14 10:32:01.430  platform.sh:55   wm adapter: hyprland
+```
+
+### Log configuration
+
+Control logging behavior in `kall.yml`:
+
+```yaml
+logging:
+  level: INFO          # Minimum level: TRACE | DEBUG | INFO | WARN | ERROR | FATAL
+  file: true           # Write to kall.log (false = stderr only)
+  max_size_mb: 1       # Rotate threshold in megabytes
+  keep_rotated: 3      # Number of rotated files to keep
+```
+
+---
 
 ## kall doctor
 
-The `doctor` command performs a comprehensive health check of your kall installation:
+The built-in diagnostic tool checks your installation:
 
 ```bash
 kall doctor
 ```
 
-It validates:
+It verifies:
 
-- **Configuration** -- checks that `kall.yml` exists and parses correctly against the config schema
-- **Core dependencies** -- verifies that `yq` and `jq` are installed
-- **Menu backend** -- checks that the configured backend binary exists
-- **Module dependencies** -- for each installed module, checks that all declared `requires.adapter_tools` for the current session type are installed
-- **Palette validity** -- validates palette files against `schemas/palette.schema.yml`
-- **Config version** -- detects outdated `kall.yml` format and suggests migration steps
+- **Dependencies** — all framework deps (`yq`, `jq`, menu backend) and per-module deps are installed.
+- **Configuration** — `kall.yml` validates against the config schema.
+- **Modules** — all listed modules exist and have valid `module.yml` files.
+- **Theme** — the active palette exists and contains all required color variables.
+- **Log files** — reports log file sizes and rotation status.
+- **Platform** — detects display server and window manager.
 
-Example output:
+Run `kall doctor` after installation, after updates, or any time something seems wrong.
 
-```
-[OK]   kall.yml found at ~/.config/kall/kall.yml
-[OK]   yq installed (v4.35.1)
-[OK]   jq installed (jq-1.7)
-[OK]   rofi installed
-[OK]   Module: power -- all deps satisfied
-[OK]   Module: clipboard -- all deps satisfied
-[WARN] Module: screenshot -- missing: slurp (wayland area selection)
-[OK]   Palette: catppuccin-mocha -- valid
-[OK]   Config version: current
-```
-
-Warnings indicate optional or degraded functionality. Errors indicate problems that will prevent modules from working.
-
-## Log rotation
-
-kall rotates `kall.log` when it exceeds the configured size threshold. Rotation is handled by `_kall_log_rotate()` in `lib/log.sh`.
-
-### How it works
-
-1. At startup, kall checks the size of `kall.log`
-2. If the file exceeds `KALL_LOG_MAX_SIZE_MB` (default: 1 MB), rotation triggers
-3. Existing rotated files are shifted: `kall.log.2` becomes `kall.log.3`, `kall.log.1` becomes `kall.log.2`
-4. The current `kall.log` becomes `kall.log.1`
-5. A new empty `kall.log` is created for future writes
-6. Files beyond `KALL_LOG_KEEP_ROTATED` (default: 3) are deleted
-
-### Configuration
-
-Control rotation behavior in `kall.yml`:
-
-```yaml
-logging:
-  max_size_mb: 1       # Rotate when kall.log exceeds 1 MB
-  keep_rotated: 3      # Keep kall.log.1, kall.log.2, kall.log.3
-```
-
-### Invariants
-
-- **INV-LOG-03:** Log rotation never blocks startup. The rotation function catches all errors and continues silently.
-- Rotation uses `stat` for file size checks, with a macOS-compatible fallback (`stat -f%z` vs `stat -c%s`).
+---
 
 ## Common issues
 
-### Module fails with "backend adapter not found"
+### Menu does not appear
 
-The configured `menu_backend` in `kall.yml` does not match any installed backend. Check the value:
+1. Check that your menu backend is installed: `which rofi` (or your configured backend).
+2. Verify the backend setting: check `menu_backend` in `kall.yml`.
+3. Run with debug mode: `kall --debug launcher` and check the output.
 
-```bash
-grep menu_backend ~/.config/kall/kall.yml
-```
+### Keybindings not working
 
-Valid backends: `rofi`, `wofi`, `fuzzel`, `tofi`, `dmenu`, `fzf`. Make sure the corresponding binary is installed.
+1. Verify injection: open your WM config and look for the `# >>> kall keybinds >>>` block.
+2. Re-inject: `kall keybinds inject` (safe to re-run — it replaces the existing block).
+3. Reload your WM config (e.g., `hyprctl reload` or `i3-msg reload`).
 
-### "yq not found" errors
+### Theme not applying
 
-kall requires `yq` (the Go-based YAML processor by Mike Farah) for configuration parsing. Install it:
+1. Verify the palette exists: `kall theme list`.
+2. Re-set the theme: `kall theme set <name>`.
+3. Check that `appearance.managed` is not set to `false` in `kall.yml`.
 
-```bash
-# Arch
-pacman -S go-yq
+### Wallbash not working
 
-# macOS
-brew install yq
+1. Check that ImageMagick is installed: `which convert` or `which magick`.
+2. Verify wallbash is enabled: `dynamic_theme: true` in `kall.yml` or `kall theme wallbash on`.
+3. Make sure a wallpaper is set. Wallbash falls back to the static palette if no wallpaper is detected.
 
-# Other
-# Download from https://github.com/mikefarah/yq/releases
-```
+### Module reports missing dependency
 
-Do not confuse it with the Python-based `yq` wrapper around `jq`. kall requires the Go binary.
+1. Run `kall doctor` to see all missing deps.
+2. Install the missing package with your system package manager.
+3. Some deps are optional — the module will work with reduced functionality.
 
-### Theme colors not applying
+### Config validation errors
 
-1. Check that your palette file is valid: `kall doctor`
-2. Regenerate backend themes: `./backends/generate-themes.sh`
-3. If using wallbash, verify ImageMagick is installed: `command -v convert`
+1. Run `kall doctor` to see the specific validation error.
+2. Check `kall.yml` syntax — a common issue is incorrect indentation.
+3. kall falls back to built-in defaults for any invalid values, so it will still start.
 
-### Keybindings not working after inject
+---
 
-1. Verify the keybindings were written: search for `>>> kall keybinds >>>` in your WM config
-2. Reload your WM config (e.g., `hyprctl reload` for Hyprland, `i3-msg reload` for i3)
-3. Check that the `kall` binary is in your PATH from the WM's perspective
-
-### Module shows no menu items
-
-1. Run in debug mode: `kall --debug <module>`
-2. Check `debug.log` for errors during menu construction
-3. Verify required tools are installed: `kall doctor`
-
-### Permission denied errors
-
-kall never requires root privileges for normal operation. If you see permission errors:
-
-1. Check file ownership: `ls -la ~/.config/kall/`
-2. Ensure XDG directories are writable
-3. If using the curl installer, do not pipe through `sudo bash`
-
-### High disk usage from logs
-
-If log files grow too large, reduce the rotation threshold or disable file logging:
-
-```yaml
-logging:
-  max_size_mb: 1
-  keep_rotated: 1
-```
-
-To clean up existing logs manually:
-
-```bash
-rm -f ~/.local/state/kall/logs/*.log*
-```
+This section will grow as issues are reported. If you encounter a problem not listed here, run `kall --debug <command>` and check the log output for clues.


### PR DESCRIPTION
Closes #67

## Summary
7 user documentation pages, all fully written (not stubs).

## Pages
- getting-started.mdx — install, setup, first run
- configuration.mdx — complete kall.yml reference
- modules.mdx — 26-module catalog table
- keybindings.mdx — normalized format, WM translation, injection
- themes.mdx — 6 palettes, wallbash, custom palettes
- troubleshooting.mdx — debug mode, logs, kall doctor
- faq.mdx — 9 questions answered