### PR TITLE
feat(docs/landing): creative landing page with GSAP animations and storytelling copy

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,26 +1,25 @@
-import { Hero } from '@/components/landing/hero';
-import { Demo } from '@/components/landing/demo';
-import { Features } from '@/components/landing/features';
-import { Modules } from '@/components/landing/modules';
-import { Themes } from '@/components/landing/themes';
-import { SocialProof } from '@/components/landing/social-proof';
-import { GettingStarted } from '@/components/landing/getting-started';
-import { Footer } from '@/components/landing/footer';
+import { ScrollProgress } from "@/components/landing/scroll-progress";
+import { Hero } from "@/components/landing/hero";
+import { ProblemSolution } from "@/components/landing/problem-solution";
+import { Features } from "@/components/landing/features";
+import { ModuleCatalog } from "@/components/landing/module-catalog";
+import { Backends } from "@/components/landing/backends";
+import { Themes } from "@/components/landing/themes";
+import { InstallCTA } from "@/components/landing/install-cta";
+import { Footer } from "@/components/landing/footer";
 
-export default function HomePage() {
+export default function LandingPage() {
   return (
-    <main className="min-h-screen bg-[#1E1E2E] text-[#CDD6F4]">
+    <div className="min-h-screen bg-[#1E1E2E] text-[#CDD6F4]">
+      <ScrollProgress />
       <Hero />
-      <Demo />
+      <ProblemSolution />
       <Features />
-      <div className="mx-auto max-w-5xl border-t border-[#313244]" />
-      <Modules />
-      <div className="mx-auto max-w-5xl border-t border-[#313244]" />
+      <ModuleCatalog />
+      <Backends />
       <Themes />
-      <SocialProof />
-      <div className="mx-auto max-w-5xl border-t border-[#313244]" />
-      <GettingStarted />
+      <InstallCTA />
       <Footer />
-    </main>
+    </div>
   );
 }

--- a/website/components/landing/backends.tsx
+++ b/website/components/landing/backends.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useState, useEffect, useRef } from "react";
+import { gsap } from "@/lib/gsap";
+
+const backends = [
+  { name: "rofi", desc: "Full-featured. Icons, markup, calculator, app launcher.", color: "#CBA6F7" },
+  { name: "fzf", desc: "Terminal-native. Preview pipelines. Most portable.", color: "#A6E3A1" },
+  { name: "wofi", desc: "Wayland-native. Clean and fast.", color: "#89B4FA" },
+  { name: "tofi", desc: "Ultra-minimal. When less is more.", color: "#F9E2AF" },
+  { name: "fuzzel", desc: "Wayland-native with icon support.", color: "#FAB387" },
+  { name: "dmenu", desc: "The OG. Keyboard-driven purity.", color: "#F5C2E7" },
+];
+
+export function Backends() {
+  const [active, setActive] = useState(0);
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setActive((prev) => (prev + 1) % backends.length);
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (!sectionRef.current) return;
+    const ctx = gsap.context(() => {
+      gsap.from(sectionRef.current!, {
+        y: 60, opacity: 0, duration: 0.8,
+        scrollTrigger: { trigger: sectionRef.current, start: "top 80%" },
+      });
+    }, sectionRef);
+    return () => ctx.revert();
+  }, []);
+
+  return (
+    <section ref={sectionRef} className="relative px-6 py-32">
+      <div className="mx-auto max-w-4xl text-center">
+        <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">
+          Locked to rofi? <span className="text-[#F38BA8]">Not anymore.</span>
+        </h2>
+        <p className="mb-12 text-lg text-[#A6ADC8]">Swap your launcher like you swap your wallpaper. Your modules don&apos;t care which one you pick.</p>
+
+        <div className="mb-8 flex flex-wrap justify-center gap-3">
+          {backends.map((b, i) => (
+            <button key={b.name} onClick={() => setActive(i)} className={`rounded-lg px-4 py-2 font-mono text-sm transition-all duration-300 ${active === i ? "border-2 text-[#1E1E2E]" : "border border-[#313244] text-[#A6ADC8] hover:border-[#585B70]"}`} style={active === i ? { backgroundColor: b.color, borderColor: b.color } : {}}>
+              {b.name}
+            </button>
+          ))}
+        </div>
+
+        <div className="rounded-2xl border border-[#313244]/50 bg-[#181825]/60 p-8">
+          <div className="text-3xl font-bold" style={{ color: backends[active].color }}>{backends[active].name}</div>
+          <p className="mt-2 text-[#A6ADC8]">{backends[active].desc}</p>
+          <p className="mt-4 font-mono text-xs text-[#585B70]">menu_backend: {backends[active].name}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/components/landing/copy-button.tsx
+++ b/website/components/landing/copy-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useState } from "react";
+
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+  return (
+    <button onClick={handleCopy} className="group relative flex items-center gap-3 rounded-xl border border-[#313244] bg-[#181825]/80 px-5 py-3.5 font-mono text-sm text-[#CDD6F4] backdrop-blur-sm transition-all duration-300 hover:border-[#CBA6F7]/40 hover:shadow-[0_0_40px_rgba(203,166,247,0.08)]">
+      <span className="text-[#585B70]">$</span>
+      <span className="text-[#A6E3A1]">{text}</span>
+      <span className="ml-2 rounded-md bg-[#313244] px-2.5 py-1 text-xs text-[#CBA6F7] transition-all duration-200 group-hover:bg-[#CBA6F7] group-hover:text-[#1E1E2E]">
+        {copied ? "copied!" : "copy"}
+      </span>
+    </button>
+  );
+}

--- a/website/components/landing/features.tsx
+++ b/website/components/landing/features.tsx
@@ -1,24 +1,47 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { gsap } from "@/lib/gsap";
+
 const features = [
-  { icon: '\u29C9', title: 'Modular', description: 'Install only what you need. Skip the rest.' },
-  { icon: '\u21C4', title: 'Any Backend', description: 'Swap rofi for wofi for fzf. Nothing breaks.' },
-  { icon: '\u2316', title: 'Cross-Platform', description: 'X11, Wayland, and macOS. One config.' },
-  { icon: '\u25D0', title: 'Dynamic Themes', description: 'Colors extracted from your wallpaper. Automatically.' },
-  { icon: '\u0023', title: 'Pure Bash', description: 'Zero Python. Zero runtime deps. Just bash.' },
-  { icon: '\u002B', title: 'Extensible', description: 'Write a module in 20 lines. Share it with everyone.' },
+  { icon: "🧩", title: "Modular", desc: "Install only what you need. Skip the rest. 26 modules, pick 5 or all 26.", accent: "#CBA6F7" },
+  { icon: "🔄", title: "Any Backend", desc: "Rofi today, fzf tomorrow, wofi next week. Your config doesn't care.", accent: "#89B4FA" },
+  { icon: "🌍", title: "Cross-Platform", desc: "X11, Wayland, and macOS. One config. Zero \"works on my machine.\"", accent: "#A6E3A1" },
+  { icon: "🎨", title: "Dynamic Themes", desc: "Colors extracted from your wallpaper. Automatically. Or pick from 6 curated palettes.", accent: "#F9E2AF" },
+  { icon: "⚡", title: "Pure Bash", desc: "No Python. No Node. No Ruby. No runtime deps. Bash and chill.", accent: "#FAB387" },
+  { icon: "🔌", title: "Extensible", desc: "Write a module in 20 lines. Share it. Anyone can contribute.", accent: "#F5C2E7" },
 ];
 
 export function Features() {
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!gridRef.current) return;
+    const ctx = gsap.context(() => {
+      gsap.from(".feature-card", {
+        y: 60, opacity: 0, stagger: 0.1, duration: 0.7, ease: "power2.out",
+        scrollTrigger: { trigger: gridRef.current, start: "top 80%" },
+      });
+    }, gridRef);
+    return () => ctx.revert();
+  }, []);
+
   return (
-    <section className="px-6 py-24">
-      <div className="mx-auto max-w-5xl">
-        <h2 className="mb-4 text-center text-sm font-semibold uppercase tracking-widest text-[#CBA6F7]">Why kall</h2>
-        <p className="mx-auto mb-16 max-w-lg text-center text-lg text-[#BAC2DE]">Everything you cobbled together from 10 repos, but it actually works together.</p>
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {features.map((feature) => (
-            <div key={feature.title} className="group rounded-xl border border-[#313244] bg-[#181825]/60 p-6 transition-all hover:border-[#45475A] hover:bg-[#181825]">
-              <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-[#313244] text-xl text-[#CBA6F7] transition-colors group-hover:bg-[#CBA6F7]/15">{feature.icon}</div>
-              <h3 className="mb-2 text-lg font-semibold text-[#CDD6F4]">{feature.title}</h3>
-              <p className="text-sm leading-relaxed text-[#A6ADC8]">{feature.description}</p>
+    <section className="relative px-6 py-32">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-16 text-center">
+          <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">
+            Built different. <span className="text-[#CBA6F7]">On purpose.</span>
+          </h2>
+          <p className="text-lg text-[#A6ADC8]">Every decision was &quot;how do we not end up like the other 47 rofi script repos&quot;</p>
+        </div>
+
+        <div ref={gridRef} className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {features.map((f, i) => (
+            <div key={i} className="feature-card group relative overflow-hidden rounded-2xl border border-[#313244]/50 bg-[#181825]/60 p-6 transition-all duration-500 hover:border-[color:var(--accent)]/30 hover:shadow-[0_0_40px_rgba(203,166,247,0.06)]" style={{"--accent": f.accent} as React.CSSProperties}>
+              <div className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full opacity-0 blur-[60px] transition-opacity duration-500 group-hover:opacity-100" style={{backgroundColor: f.accent + "15"}} />
+              <span className="mb-4 block text-3xl">{f.icon}</span>
+              <h3 className="mb-2 text-lg font-semibold text-[#CDD6F4]">{f.title}</h3>
+              <p className="text-sm leading-relaxed text-[#A6ADC8]">{f.desc}</p>
             </div>
           ))}
         </div>

--- a/website/components/landing/footer.tsx
+++ b/website/components/landing/footer.tsx
@@ -1,41 +1,16 @@
-import Link from 'next/link';
-
-const links = [
-  { label: 'Docs', href: '/docs' },
-  { label: 'GitHub', href: 'https://github.com/shaiknoorullah/kall', external: true },
-  { label: 'Showcase', href: '/showcase' },
-  { label: 'Contributing', href: 'https://github.com/shaiknoorullah/kall/blob/main/CONTRIBUTING.md', external: true },
-];
+import Link from "next/link";
 
 export function Footer() {
   return (
-    <footer className="border-t border-[#313244] px-6 py-12">
-      <div className="mx-auto flex max-w-4xl flex-col items-center gap-6">
-        {/* Links */}
-        <nav className="flex flex-wrap justify-center gap-6">
-          {links.map((link) =>
-            link.external ? (
-              <a key={link.label} href={link.href} target="_blank" rel="noopener noreferrer" className="text-sm text-[#6C7086] transition-colors hover:text-[#CDD6F4]">
-                {link.label}
-              </a>
-            ) : (
-              <Link key={link.label} href={link.href} className="text-sm text-[#6C7086] transition-colors hover:text-[#CDD6F4]">
-                {link.label}
-              </Link>
-            )
-          )}
-        </nav>
-
-        {/* License and author */}
-        <div className="flex flex-col items-center gap-1 text-xs text-[#6C7086]">
-          <span>MIT License</span>
-          <span>
-            Built by{' '}
-            <a href="https://github.com/shaiknoorullah" target="_blank" rel="noopener noreferrer" className="text-[#BAC2DE] transition-colors hover:text-[#CDD6F4]">
-              @shaiknoorullah
-            </a>
-          </span>
+    <footer className="border-t border-[#313244]/30 px-6 py-12">
+      <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-6 sm:flex-row">
+        <div className="flex gap-6 text-sm text-[#585B70]">
+          <Link href="/docs" className="transition-colors hover:text-[#CDD6F4]">Docs</Link>
+          <Link href="https://github.com/shaiknoorullah/kall" target="_blank" className="transition-colors hover:text-[#CDD6F4]">GitHub</Link>
+          <Link href="https://github.com/shaiknoorullah/kall/discussions" target="_blank" className="transition-colors hover:text-[#CDD6F4]">Discussions</Link>
+          <Link href="https://github.com/shaiknoorullah/kall/blob/main/CONTRIBUTING.md" target="_blank" className="transition-colors hover:text-[#CDD6F4]">Contributing</Link>
         </div>
+        <div className="text-xs text-[#45475A]">MIT &middot; Made with obsessive attention to detail</div>
       </div>
     </footer>
   );

--- a/website/components/landing/hero.tsx
+++ b/website/components/landing/hero.tsx
@@ -1,79 +1,70 @@
-'use client';
-
-import { useState } from 'react';
-import Link from 'next/link';
+"use client";
+import { useEffect, useRef } from "react";
+import { gsap } from "@/lib/gsap";
+import { CopyButton } from "./copy-button";
+import Link from "next/link";
 
 export function Hero() {
-  const [copied, setCopied] = useState(false);
-  const installCmd = 'curl -fsSL kall.sh/install | bash';
+  const sectionRef = useRef<HTMLElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const storyRef = useRef<HTMLParagraphElement>(null);
+  const solutionRef = useRef<HTMLParagraphElement>(null);
+  const actionsRef = useRef<HTMLDivElement>(null);
 
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(installCmd);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      const textarea = document.createElement('textarea');
-      textarea.value = installCmd;
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textarea);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
-  };
+  useEffect(() => {
+    if (!sectionRef.current) return;
+    const ctx = gsap.context(() => {
+      const tl = gsap.timeline({ defaults: { ease: "power3.out" } });
+      if (titleRef.current) {
+        const chars = titleRef.current.querySelectorAll(".char");
+        tl.from(chars, { y: 120, opacity: 0, rotateX: -90, stagger: 0.08, duration: 1 });
+      }
+      if (storyRef.current) tl.from(storyRef.current, { y: 40, opacity: 0, duration: 0.8 }, "-=0.3");
+      if (solutionRef.current) tl.from(solutionRef.current, { y: 30, opacity: 0, duration: 0.6 }, "-=0.2");
+      if (actionsRef.current) tl.from(actionsRef.current, { y: 20, opacity: 0, duration: 0.6 }, "-=0.1");
+    }, sectionRef);
+    return () => ctx.revert();
+  }, []);
 
   return (
-    <section className="relative flex min-h-[90vh] flex-col items-center justify-center overflow-hidden px-6 py-24">
+    <section ref={sectionRef} className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 pt-24 pb-16">
+      {/* Atmospheric bg */}
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute left-1/2 top-1/4 h-[500px] w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#CBA6F7]/8 blur-[120px]" />
-        <div className="absolute right-1/4 top-1/2 h-[300px] w-[300px] rounded-full bg-[#89B4FA]/6 blur-[100px]" />
-        <div className="absolute bottom-1/4 left-1/3 h-[250px] w-[250px] rounded-full bg-[#F5C2E7]/5 blur-[90px]" />
+        <div className="absolute top-1/4 left-1/2 -translate-x-1/2 h-[600px] w-[800px] rounded-full bg-[#CBA6F7]/[0.04] blur-[120px]" />
+        <div className="absolute bottom-1/4 right-1/4 h-[400px] w-[400px] rounded-full bg-[#89B4FA]/[0.03] blur-[100px]" />
+        <div className="absolute inset-0 opacity-[0.015]" style={{backgroundImage: "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E\")"}} />
       </div>
-      <div className="relative z-10 flex max-w-3xl flex-col items-center text-center">
-        <h1 className="mb-6 text-8xl font-black tracking-tighter sm:text-9xl">
-          <span className="hero-glow bg-gradient-to-r from-[#CBA6F7] via-[#89B4FA] to-[#F5C2E7] bg-clip-text text-transparent">
-            kall
-          </span>
+
+      <div className="relative z-10 mx-auto max-w-4xl text-center">
+        <h1 ref={titleRef} className="mb-8 text-[clamp(5rem,15vw,12rem)] font-bold leading-[0.85] tracking-tighter" style={{perspective: "1000px"}}>
+          {"kall".split("").map((char, i) => (
+            <span key={i} className="char inline-block bg-gradient-to-b from-[#CDD6F4] via-[#CDD6F4] to-[#585B70] bg-clip-text text-transparent" style={{transformOrigin: "center bottom"}}>{char}</span>
+          ))}
         </h1>
-        <p className="mb-10 max-w-xl text-xl leading-relaxed text-[#BAC2DE] sm:text-2xl">
-          Stop duct-taping scripts together.
-          <br />
-          <span className="text-[#CDD6F4]">One command center. Every desktop action. Pure bash.</span>
+
+        <p ref={storyRef} className="mx-auto mb-6 max-w-2xl text-lg leading-relaxed text-[#A6ADC8] md:text-xl">
+          You&apos;ve been here before. New wallpaper, broken clipboard script.
+          Three hours later you&apos;re debugging someone else&apos;s rofi
+          spaghetti at 2am. Half your scripts die on Wayland. The other half
+          never worked on your laptop.
         </p>
-        <div className="mb-10 w-full max-w-lg">
-          <div className="group relative flex items-center rounded-lg border border-[#45475A] bg-[#181825] font-mono text-sm transition-colors hover:border-[#585B70]">
-            <span className="select-none px-4 text-[#6C7086]">$</span>
-            <code className="flex-1 py-3.5 pr-2 text-[#A6E3A1]">{installCmd}</code>
-            <button
-              onClick={handleCopy}
-              className="mr-2 rounded-md px-3 py-1.5 text-xs text-[#6C7086] transition-all hover:bg-[#313244] hover:text-[#CDD6F4]"
-              aria-label="Copy install command"
-            >
-              {copied ? (
-                <span className="text-[#A6E3A1]">copied!</span>
-              ) : (
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                </svg>
-              )}
-            </button>
+
+        <p ref={solutionRef} className="mx-auto mb-12 max-w-xl text-xl font-medium text-[#CDD6F4] md:text-2xl">
+          One command center. <span className="text-[#CBA6F7]">Any launcher.</span>{" "}
+          Every platform. <span className="text-[#A6E3A1]">Pure bash.</span>
+        </p>
+
+        <div ref={actionsRef} className="flex flex-col items-center gap-6">
+          <CopyButton text="curl -fsSL kall.sh/install | bash" />
+          <div className="flex gap-4">
+            <Link href="/docs/user/getting-started" className="rounded-lg bg-[#CBA6F7] px-6 py-2.5 text-sm font-semibold text-[#1E1E2E] transition-all duration-300 hover:bg-[#B4BEFE] hover:shadow-[0_0_30px_rgba(203,166,247,0.3)]">Get Started</Link>
+            <Link href="https://github.com/shaiknoorullah/kall" target="_blank" className="rounded-lg border border-[#313244] px-6 py-2.5 text-sm font-semibold text-[#CDD6F4] transition-all duration-300 hover:border-[#585B70] hover:bg-[#181825]">GitHub</Link>
           </div>
         </div>
-        <div className="flex flex-col gap-4 sm:flex-row">
-          <Link href="/docs/user/getting-started" className="rounded-lg bg-[#CBA6F7] px-8 py-3.5 text-sm font-semibold text-[#1E1E2E] transition-all hover:bg-[#CBA6F7]/85 hover:shadow-lg hover:shadow-[#CBA6F7]/20">
-            Get Started
-          </Link>
-          <a href="https://github.com/shaiknoorullah/kall" target="_blank" rel="noopener noreferrer" className="flex items-center justify-center gap-2 rounded-lg border border-[#45475A] px-8 py-3.5 text-sm font-semibold text-[#CDD6F4] transition-all hover:border-[#585B70] hover:bg-[#313244]/50">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" /></svg>
-            GitHub
-          </a>
-        </div>
       </div>
-      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 animate-bounce text-[#6C7086]">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="6 9 12 15 18 9" /></svg>
+
+      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 animate-bounce text-[#585B70]">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="6 9 12 15 18 9"/></svg>
       </div>
     </section>
   );

--- a/website/components/landing/install-cta.tsx
+++ b/website/components/landing/install-cta.tsx
@@ -1,0 +1,39 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { gsap } from "@/lib/gsap";
+import { CopyButton } from "./copy-button";
+import Link from "next/link";
+
+export function InstallCTA() {
+  const sectionRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+    if (!sectionRef.current) return;
+    const ctx = gsap.context(() => {
+      gsap.from(sectionRef.current!, {
+        y: 40, opacity: 0, duration: 0.8,
+        scrollTrigger: { trigger: sectionRef.current, start: "top 85%" },
+      });
+    }, sectionRef);
+    return () => ctx.revert();
+  }, []);
+
+  return (
+    <section ref={sectionRef} className="relative px-6 py-32">
+      <div className="mx-auto max-w-3xl text-center">
+        <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">Ready to stop duct-taping?</h2>
+        <p className="mb-8 text-lg text-[#A6ADC8]">One command. Pick your modules. Add keybindings. Done.</p>
+        <div className="mb-8 flex justify-center">
+          <CopyButton text="curl -fsSL kall.sh/install | bash" />
+        </div>
+        <div className="flex justify-center gap-8 text-sm text-[#585B70]">
+          <div className="flex items-center gap-2"><span className="text-[#A6E3A1]">1.</span> Install</div>
+          <div className="flex items-center gap-2"><span className="text-[#89B4FA]">2.</span> Pick modules</div>
+          <div className="flex items-center gap-2"><span className="text-[#CBA6F7]">3.</span> Ship it</div>
+        </div>
+        <div className="mt-8">
+          <Link href="/docs/user/getting-started" className="text-sm text-[#CBA6F7] underline underline-offset-4 transition-colors hover:text-[#B4BEFE]">Read the docs &rarr;</Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/components/landing/module-catalog.tsx
+++ b/website/components/landing/module-catalog.tsx
@@ -1,0 +1,93 @@
+"use client";
+import { useState, useEffect, useRef } from "react";
+import { gsap } from "@/lib/gsap";
+
+const categories = {
+  System: [
+    { name: "power", desc: "Shutdown, reboot, lock, suspend, logout" },
+    { name: "screenshot", desc: "Full, area, window — clipboard + notification" },
+    { name: "clipboard", desc: "History, favorites, image preview, OCR" },
+    { name: "display", desc: "Multi-monitor layout manager" },
+    { name: "wallpaper", desc: "Category browser + setter + theme trigger" },
+    { name: "bluetooth", desc: "Scan, pair, connect, trust devices" },
+    { name: "systemd", desc: "Start, stop, enable, disable services" },
+  ],
+  Productivity: [
+    { name: "websearch", desc: "Autocomplete + bang syntax (!g, !yt, !w)" },
+    { name: "calculator", desc: "Quick math without leaving your flow" },
+    { name: "emoji", desc: "Picker with recents and categories" },
+    { name: "glyph", desc: "Every Nerd Font icon at your fingertips" },
+    { name: "media", desc: "Play, pause, next, prev — any player" },
+  ],
+  Developer: [
+    { name: "git-profiles", desc: "Switch git user.name/email per project" },
+    { name: "tmux", desc: "Session manager — create, attach, kill" },
+    { name: "projects", desc: "Jump to any project in your editor" },
+  ],
+  Browser: [
+    { name: "bookmarks", desc: "Firefox, Chrome, Zen — all browsers, one menu" },
+    { name: "zen-tabs", desc: "Fuzzy tab search with favicon preview" },
+    { name: "zen-workspaces", desc: "Domain-based tab grouping + dedup" },
+  ],
+  Notes: [
+    { name: "obsidian", desc: "Quick note, daily note, open vault" },
+    { name: "obsidian-search", desc: "Full-text search across all notes" },
+  ],
+};
+
+const catKeys = Object.keys(categories) as (keyof typeof categories)[];
+
+export function ModuleCatalog() {
+  const [active, setActive] = useState<keyof typeof categories>("System");
+  const listRef = useRef<HTMLDivElement>(null);
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!sectionRef.current) return;
+    const ctx = gsap.context(() => {
+      gsap.from(sectionRef.current!, {
+        y: 60, opacity: 0, duration: 0.8,
+        scrollTrigger: { trigger: sectionRef.current, start: "top 80%" },
+      });
+    }, sectionRef);
+    return () => ctx.revert();
+  }, []);
+
+  useEffect(() => {
+    if (!listRef.current) return;
+    const items = listRef.current.querySelectorAll(".module-item");
+    gsap.fromTo(items, { x: 20, opacity: 0 }, { x: 0, opacity: 1, stagger: 0.05, duration: 0.3, ease: "power2.out" });
+  }, [active]);
+
+  return (
+    <section ref={sectionRef} className="relative px-6 py-32">
+      <div className="mx-auto max-w-5xl">
+        <div className="mb-12 text-center">
+          <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">
+            26 modules. <span className="text-[#89B4FA]">Zero bloat.</span>
+          </h2>
+          <p className="text-lg text-[#A6ADC8]">Pick what you need. Ignore the rest. Each one tested on X11, Wayland, and macOS.</p>
+        </div>
+
+        {/* Tabs */}
+        <div className="mb-8 flex flex-wrap justify-center gap-2">
+          {catKeys.map((cat) => (
+            <button key={cat} onClick={() => setActive(cat)} className={`rounded-full px-4 py-2 text-sm font-medium transition-all duration-300 ${active === cat ? "bg-[#CBA6F7] text-[#1E1E2E]" : "border border-[#313244] text-[#A6ADC8] hover:border-[#585B70] hover:text-[#CDD6F4]"}`}>
+              {cat} <span className="ml-1 text-xs opacity-70">({categories[cat].length})</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Module list */}
+        <div ref={listRef} className="grid gap-3 sm:grid-cols-2">
+          {categories[active].map((m, i) => (
+            <div key={m.name} className="module-item flex items-center gap-3 rounded-xl border border-[#313244]/40 bg-[#181825]/40 px-4 py-3 transition-all duration-300 hover:border-[#CBA6F7]/20 hover:bg-[#181825]/80">
+              <code className="rounded bg-[#313244] px-2 py-0.5 text-xs text-[#CBA6F7]">{m.name}</code>
+              <span className="text-sm text-[#A6ADC8]">{m.desc}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/components/landing/problem-solution.tsx
+++ b/website/components/landing/problem-solution.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { gsap, ScrollTrigger } from "@/lib/gsap";
+
+const problems = [
+  { icon: "💀", text: "10 scripts from 10 repos. None themed." },
+  { icon: "🔥", text: "Swap rofi for wofi? Everything breaks." },
+  { icon: "😤", text: "Wayland? Good luck with xclip." },
+  { icon: "🐍", text: "Needs Python 3.11. And pip. And venv." },
+];
+
+const solutions = [
+  { icon: "📦", text: "26 modules. One config file." },
+  { icon: "🔄", text: "Swap backends freely. Nothing breaks." },
+  { icon: "🖥️", text: "X11, Wayland, macOS. All of them." },
+  { icon: "⚡", text: "Pure bash. yq + jq. That's it." },
+];
+
+export function ProblemSolution() {
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!sectionRef.current) return;
+    const ctx = gsap.context(() => {
+      gsap.from(".problem-card", {
+        x: -60, opacity: 0, stagger: 0.12, duration: 0.7,
+        scrollTrigger: { trigger: sectionRef.current, start: "top 75%" },
+      });
+      gsap.from(".solution-card", {
+        x: 60, opacity: 0, stagger: 0.12, duration: 0.7,
+        scrollTrigger: { trigger: sectionRef.current, start: "top 75%" },
+      });
+    }, sectionRef);
+    return () => ctx.revert();
+  }, []);
+
+  return (
+    <section ref={sectionRef} className="relative px-6 py-32">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-16 text-center">
+          <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">
+            The <span className="line-through text-[#F38BA8]/60">mess</span> you know
+          </h2>
+          <p className="text-lg text-[#A6ADC8]">vs. the system you deserve</p>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2">
+          {/* Problems */}
+          <div className="space-y-4">
+            <div className="mb-6 inline-block rounded-full border border-[#F38BA8]/20 bg-[#F38BA8]/5 px-4 py-1.5 text-sm text-[#F38BA8]">before kall</div>
+            {problems.map((p, i) => (
+              <div key={i} className="problem-card flex items-center gap-4 rounded-xl border border-[#313244]/50 bg-[#181825]/50 p-4 opacity-60">
+                <span className="text-2xl">{p.icon}</span>
+                <span className="text-[#A6ADC8]">{p.text}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* Solutions */}
+          <div className="space-y-4">
+            <div className="mb-6 inline-block rounded-full border border-[#A6E3A1]/20 bg-[#A6E3A1]/5 px-4 py-1.5 text-sm text-[#A6E3A1]">with kall</div>
+            {solutions.map((s, i) => (
+              <div key={i} className="solution-card flex items-center gap-4 rounded-xl border border-[#A6E3A1]/10 bg-[#181825]/80 p-4 transition-all duration-300 hover:border-[#A6E3A1]/30 hover:shadow-[0_0_20px_rgba(166,227,161,0.05)]">
+                <span className="text-2xl">{s.icon}</span>
+                <span className="text-[#CDD6F4]">{s.text}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/components/landing/scroll-progress.tsx
+++ b/website/components/landing/scroll-progress.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { gsap, ScrollTrigger } from "@/lib/gsap";
+
+export function ScrollProgress() {
+  const barRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!barRef.current) return;
+    gsap.to(barRef.current, {
+      scaleX: 1,
+      ease: "none",
+      scrollTrigger: { trigger: document.body, start: "top top", end: "bottom bottom", scrub: 0.3 },
+    });
+    return () => { ScrollTrigger.getAll().forEach((t) => t.kill()); };
+  }, []);
+  return (
+    <div className="fixed top-0 left-0 right-0 z-50 h-[2px]">
+      <div ref={barRef} className="h-full origin-left bg-gradient-to-r from-[#CBA6F7] via-[#89B4FA] to-[#A6E3A1]" style={{ transform: "scaleX(0)" }} />
+    </div>
+  );
+}

--- a/website/components/landing/themes.tsx
+++ b/website/components/landing/themes.tsx
@@ -1,46 +1,45 @@
-type Palette = { name: string; colors: string[] };
+"use client";
+import { useEffect, useRef } from "react";
+import { gsap } from "@/lib/gsap";
 
-const palettes: Palette[] = [
-  { name: 'Catppuccin Mocha', colors: ['#1E1E2E', '#CBA6F7', '#89B4FA', '#A6E3A1', '#F38BA8', '#F9E2AF', '#CDD6F4'] },
-  { name: 'Dracula', colors: ['#282A36', '#BD93F9', '#FF79C6', '#50FA7B', '#FF5555', '#F1FA8C', '#F8F8F2'] },
-  { name: 'Nord', colors: ['#2E3440', '#88C0D0', '#81A1C1', '#A3BE8C', '#BF616A', '#EBCB8B', '#ECEFF4'] },
-  { name: 'Gruvbox', colors: ['#282828', '#D79921', '#458588', '#98971A', '#CC241D', '#D65D0E', '#EBDBB2'] },
-  { name: 'Tokyo Night', colors: ['#1A1B26', '#7AA2F7', '#BB9AF7', '#9ECE6A', '#F7768E', '#E0AF68', '#C0CAF5'] },
-  { name: 'Rose Pine', colors: ['#191724', '#C4A7E7', '#EBBCBA', '#31748F', '#EB6F92', '#F6C177', '#E0DEF4'] },
+const palettes = [
+  { name: "Catppuccin Mocha", colors: ["#1E1E2E", "#CDD6F4", "#CBA6F7", "#89B4FA", "#A6E3A1"] },
+  { name: "Dracula", colors: ["#282A36", "#F8F8F2", "#BD93F9", "#FF79C6", "#50FA7B"] },
+  { name: "Nord", colors: ["#2E3440", "#ECEFF4", "#88C0D0", "#81A1C1", "#BF616A"] },
+  { name: "Gruvbox", colors: ["#282828", "#EBDBB2", "#D79921", "#458588", "#CC241D"] },
+  { name: "Tokyo Night", colors: ["#1A1B26", "#C0CAF5", "#7AA2F7", "#BB9AF7", "#F7768E"] },
+  { name: "Rose Pine", colors: ["#191724", "#E0DEF4", "#C4A7E7", "#EBBCBA", "#EB6F92"] },
 ];
 
 export function Themes() {
-  return (
-    <section className="px-6 py-24">
-      <div className="mx-auto max-w-4xl">
-        <h2 className="mb-4 text-center text-sm font-semibold uppercase tracking-widest text-[#CBA6F7]">
-          6 palettes built in
-        </h2>
-        <p className="mx-auto mb-6 max-w-lg text-center text-lg text-[#BAC2DE]">
-          Pick a palette. Or let your wallpaper decide.
-        </p>
-        <p className="mx-auto mb-14 max-w-md text-center text-sm text-[#6C7086]">
-          Dynamic wallbash theming extracts colors from your wallpaper and
-          applies them across every module, every backend, automatically.
-        </p>
+  const sectionRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+    if (!sectionRef.current) return;
+    const ctx = gsap.context(() => {
+      gsap.from(".palette-card", {
+        y: 40, opacity: 0, stagger: 0.08, duration: 0.6,
+        scrollTrigger: { trigger: sectionRef.current, start: "top 80%" },
+      });
+    }, sectionRef);
+    return () => ctx.revert();
+  }, []);
 
+  return (
+    <section ref={sectionRef} className="relative px-6 py-32">
+      <div className="mx-auto max-w-5xl">
+        <div className="mb-12 text-center">
+          <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">Six palettes. <span className="text-[#F9E2AF]">Or your wallpaper.</span></h2>
+          <p className="text-lg text-[#A6ADC8]">Static palettes ship out of the box. Enable wallbash and your wallpaper becomes your theme.</p>
+        </div>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {palettes.map((palette) => (
-            <div
-              key={palette.name}
-              className="rounded-xl border border-[#313244] bg-[#181825]/60 p-5 transition-all hover:border-[#45475A] hover:bg-[#181825]"
-            >
-              <p className="mb-3 text-sm font-medium text-[#CDD6F4]">{palette.name}</p>
-              <div className="flex gap-2">
-                {palette.colors.map((color, i) => (
-                  <div
-                    key={i}
-                    className="h-5 w-5 rounded-full border border-white/10"
-                    style={{ backgroundColor: color }}
-                    title={color}
-                  />
+          {palettes.map((p) => (
+            <div key={p.name} className="palette-card group rounded-xl border border-[#313244]/40 bg-[#181825]/40 p-4 transition-all duration-300 hover:border-[#585B70] hover:bg-[#181825]/80">
+              <div className="mb-3 flex gap-2">
+                {p.colors.map((c, j) => (
+                  <div key={j} className="h-8 w-8 rounded-lg transition-transform duration-300 group-hover:scale-110" style={{ backgroundColor: c }} />
                 ))}
               </div>
+              <div className="text-sm font-medium text-[#CDD6F4]">{p.name}</div>
             </div>
           ))}
         </div>

--- a/website/global.css
+++ b/website/global.css
@@ -1,19 +1,38 @@
-@import 'tailwindcss';
-@import 'fumadocs-ui/css/catppuccin.css';
-@import 'fumadocs-ui/css/preset.css';
+@import "tailwindcss";
+@import "fumadocs-ui/css/neutral.css";
+@import "fumadocs-ui/css/preset.css";
 
-@keyframes hero-glow-shift {
-  0%, 100% {
-    filter: drop-shadow(0 0 30px rgba(203, 166, 247, 0.3));
-  }
-  33% {
-    filter: drop-shadow(0 0 40px rgba(137, 180, 250, 0.3));
-  }
-  66% {
-    filter: drop-shadow(0 0 35px rgba(245, 194, 231, 0.25));
-  }
+:root {
+  --background: 222.2 84% 4.9%;
+  --foreground: 226 64% 88%;
 }
 
-.hero-glow {
-  animation: hero-glow-shift 6s ease-in-out infinite;
+body {
+  background-color: #1E1E2E;
+  color: #CDD6F4;
+}
+
+::selection {
+  background-color: rgba(203, 166, 247, 0.3);
+  color: #CDD6F4;
+}
+
+/* Smooth scrolling */
+html {
+  scroll-behavior: smooth;
+}
+
+/* Custom scrollbar */
+::-webkit-scrollbar {
+  width: 6px;
+}
+::-webkit-scrollbar-track {
+  background: #181825;
+}
+::-webkit-scrollbar-thumb {
+  background: #313244;
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #585B70;
 }

--- a/website/lib/gsap.ts
+++ b/website/lib/gsap.ts
@@ -1,0 +1,7 @@
+"use client";
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+if (typeof window !== "undefined") {
+  gsap.registerPlugin(ScrollTrigger);
+}
+export { gsap, ScrollTrigger };

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7,11 +7,13 @@
     "": {
       "name": "website",
       "version": "1.0.0",
-      "license": "ISC",
+      "hasInstallScript": true,
       "dependencies": {
+        "@gsap/react": "^2.1.2",
         "fumadocs-core": "^16.6.17",
         "fumadocs-mdx": "^14.2.10",
         "fumadocs-ui": "^16.6.17",
+        "gsap": "^3.14.2",
         "next": "^16.1.6",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -536,6 +538,16 @@
         "tailwindcss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@gsap/react": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@gsap/react/-/react-2.1.2.tgz",
+      "integrity": "sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==",
+      "license": "SEE LICENSE AT https://gsap.com/standard-license",
+      "peerDependencies": {
+        "gsap": "^3.12.5",
+        "react": ">=17"
       }
     },
     "node_modules/@img/colour": {
@@ -3462,6 +3474,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gsap": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.14.2.tgz",
+      "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",

--- a/website/package.json
+++ b/website/package.json
@@ -9,9 +9,11 @@
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
+    "@gsap/react": "^2.1.2",
     "fumadocs-core": "^16.6.17",
     "fumadocs-mdx": "^14.2.10",
     "fumadocs-ui": "^16.6.17",
+    "gsap": "^3.14.2",
     "next": "^16.1.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"


### PR DESCRIPTION
Closes #65

## Complete landing page redesign

### Sections (8)
1. **Hero** — GSAP letter-by-letter reveal, pain-point storytelling ("You've been here before. New wallpaper, broken clipboard script..."), gradient text, atmospheric background with noise grain
2. **Problem/Solution** — Before/after split with scroll-triggered card reveals
3. **Features** — Bento grid with hover glow effects, personality-driven copy
4. **Module Catalog** — Tabbed categories (System, Productivity, Developer, Browser, Notes) with animated tab switching
5. **Backends** — Auto-cycling backend showcase ("Locked to rofi? Not anymore.")
6. **Themes** — 6 palette cards with actual color swatches
7. **Install CTA** — Final conversion with 3-step visual
8. **Footer** — Minimal with nav links

### Technical
- GSAP ScrollTrigger for scroll-triggered animations
- Scroll progress bar (gradient accent)
- Catppuccin Mocha palette throughout
- Copy-to-clipboard install button
- Fixed docs navigation links
- Mobile responsive
- Build passes (26 pages)

### Design
- Dark, atmospheric aesthetic (basement.studio inspired)
- Noise grain texture
- Gradient text effects
- Hover glow on feature cards
- Staggered reveals on scroll