### PR TITLE
fix(docs/landing): fix invisible sections and janky tab animations

### DIFF
--- a/website/components/landing/backends.tsx
+++ b/website/components/landing/backends.tsx
@@ -1,6 +1,5 @@
 "use client";
-import { useState, useEffect, useRef } from "react";
-import { gsap } from "@/lib/gsap";
+import { useState } from "react";
 
 const backends = [
   { name: "rofi", desc: "Full-featured. Icons, markup, calculator, app launcher.", color: "#CBA6F7" },
@@ -13,43 +12,24 @@ const backends = [
 
 export function Backends() {
   const [active, setActive] = useState(0);
-  const sectionRef = useRef<HTMLElement>(null);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setActive((prev) => (prev + 1) % backends.length);
-    }, 3000);
-    return () => clearInterval(interval);
-  }, []);
-
-  useEffect(() => {
-    if (!sectionRef.current) return;
-    const ctx = gsap.context(() => {
-      gsap.from(sectionRef.current!, {
-        y: 60, opacity: 0, duration: 0.8,
-        scrollTrigger: { trigger: sectionRef.current, start: "top 80%" },
-      });
-    }, sectionRef);
-    return () => ctx.revert();
-  }, []);
 
   return (
-    <section ref={sectionRef} className="relative px-6 py-32">
+    <section className="relative px-6 py-24 md:py-32">
       <div className="mx-auto max-w-4xl text-center">
-        <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">
+        <h2 className="mb-4 text-3xl font-bold text-[#CDD6F4] md:text-5xl">
           Locked to rofi? <span className="text-[#F38BA8]">Not anymore.</span>
         </h2>
         <p className="mb-12 text-lg text-[#A6ADC8]">Swap your launcher like you swap your wallpaper. Your modules don&apos;t care which one you pick.</p>
 
         <div className="mb-8 flex flex-wrap justify-center gap-3">
           {backends.map((b, i) => (
-            <button key={b.name} onClick={() => setActive(i)} className={`rounded-lg px-4 py-2 font-mono text-sm transition-all duration-300 ${active === i ? "border-2 text-[#1E1E2E]" : "border border-[#313244] text-[#A6ADC8] hover:border-[#585B70]"}`} style={active === i ? { backgroundColor: b.color, borderColor: b.color } : {}}>
+            <button key={b.name} onClick={() => setActive(i)} className={`rounded-lg px-4 py-2 font-mono text-sm transition-all duration-200 ${active === i ? "text-[#1E1E2E] font-semibold" : "border border-[#313244] text-[#A6ADC8] hover:border-[#585B70]"}`} style={active === i ? { backgroundColor: b.color, borderColor: b.color } : {}}>
               {b.name}
             </button>
           ))}
         </div>
 
-        <div className="rounded-2xl border border-[#313244]/50 bg-[#181825]/60 p-8">
+        <div className="rounded-2xl border border-[#313244]/50 bg-[#181825]/60 p-8 transition-all duration-200">
           <div className="text-3xl font-bold" style={{ color: backends[active].color }}>{backends[active].name}</div>
           <p className="mt-2 text-[#A6ADC8]">{backends[active].desc}</p>
           <p className="mt-4 font-mono text-xs text-[#585B70]">menu_backend: {backends[active].name}</p>

--- a/website/components/landing/features.tsx
+++ b/website/components/landing/features.tsx
@@ -1,6 +1,4 @@
 "use client";
-import { useEffect, useRef } from "react";
-import { gsap } from "@/lib/gsap";
 
 const features = [
   { icon: "🧩", title: "Modular", desc: "Install only what you need. Skip the rest. 26 modules, pick 5 or all 26.", accent: "#CBA6F7" },
@@ -12,33 +10,19 @@ const features = [
 ];
 
 export function Features() {
-  const gridRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!gridRef.current) return;
-    const ctx = gsap.context(() => {
-      gsap.from(".feature-card", {
-        y: 60, opacity: 0, stagger: 0.1, duration: 0.7, ease: "power2.out",
-        scrollTrigger: { trigger: gridRef.current, start: "top 80%" },
-      });
-    }, gridRef);
-    return () => ctx.revert();
-  }, []);
-
   return (
-    <section className="relative px-6 py-32">
+    <section className="relative px-6 py-24 md:py-32">
       <div className="mx-auto max-w-6xl">
         <div className="mb-16 text-center">
-          <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">
+          <h2 className="mb-4 text-3xl font-bold text-[#CDD6F4] md:text-5xl">
             Built different. <span className="text-[#CBA6F7]">On purpose.</span>
           </h2>
           <p className="text-lg text-[#A6ADC8]">Every decision was &quot;how do we not end up like the other 47 rofi script repos&quot;</p>
         </div>
 
-        <div ref={gridRef} className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {features.map((f, i) => (
-            <div key={i} className="feature-card group relative overflow-hidden rounded-2xl border border-[#313244]/50 bg-[#181825]/60 p-6 transition-all duration-500 hover:border-[color:var(--accent)]/30 hover:shadow-[0_0_40px_rgba(203,166,247,0.06)]" style={{"--accent": f.accent} as React.CSSProperties}>
-              <div className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full opacity-0 blur-[60px] transition-opacity duration-500 group-hover:opacity-100" style={{backgroundColor: f.accent + "15"}} />
+            <div key={i} className="group relative overflow-hidden rounded-2xl border border-[#313244]/50 bg-[#181825]/60 p-6 transition-all duration-300 hover:border-[#585B70] hover:bg-[#181825]">
               <span className="mb-4 block text-3xl">{f.icon}</span>
               <h3 className="mb-2 text-lg font-semibold text-[#CDD6F4]">{f.title}</h3>
               <p className="text-sm leading-relaxed text-[#A6ADC8]">{f.desc}</p>

--- a/website/components/landing/install-cta.tsx
+++ b/website/components/landing/install-cta.tsx
@@ -1,26 +1,11 @@
-"use client";
-import { useEffect, useRef } from "react";
-import { gsap } from "@/lib/gsap";
 import { CopyButton } from "./copy-button";
 import Link from "next/link";
 
 export function InstallCTA() {
-  const sectionRef = useRef<HTMLElement>(null);
-  useEffect(() => {
-    if (!sectionRef.current) return;
-    const ctx = gsap.context(() => {
-      gsap.from(sectionRef.current!, {
-        y: 40, opacity: 0, duration: 0.8,
-        scrollTrigger: { trigger: sectionRef.current, start: "top 85%" },
-      });
-    }, sectionRef);
-    return () => ctx.revert();
-  }, []);
-
   return (
-    <section ref={sectionRef} className="relative px-6 py-32">
+    <section className="relative px-6 py-24 md:py-32">
       <div className="mx-auto max-w-3xl text-center">
-        <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">Ready to stop duct-taping?</h2>
+        <h2 className="mb-4 text-3xl font-bold text-[#CDD6F4] md:text-5xl">Ready to stop duct-taping?</h2>
         <p className="mb-8 text-lg text-[#A6ADC8]">One command. Pick your modules. Add keybindings. Done.</p>
         <div className="mb-8 flex justify-center">
           <CopyButton text="curl -fsSL kall.sh/install | bash" />

--- a/website/components/landing/module-catalog.tsx
+++ b/website/components/landing/module-catalog.tsx
@@ -1,6 +1,5 @@
 "use client";
-import { useState, useEffect, useRef } from "react";
-import { gsap } from "@/lib/gsap";
+import { useState } from "react";
 
 const categories = {
   System: [
@@ -35,53 +34,33 @@ const categories = {
   ],
 };
 
-const catKeys = Object.keys(categories) as (keyof typeof categories)[];
+type Category = keyof typeof categories;
+const catKeys = Object.keys(categories) as Category[];
 
 export function ModuleCatalog() {
-  const [active, setActive] = useState<keyof typeof categories>("System");
-  const listRef = useRef<HTMLDivElement>(null);
-  const sectionRef = useRef<HTMLElement>(null);
-
-  useEffect(() => {
-    if (!sectionRef.current) return;
-    const ctx = gsap.context(() => {
-      gsap.from(sectionRef.current!, {
-        y: 60, opacity: 0, duration: 0.8,
-        scrollTrigger: { trigger: sectionRef.current, start: "top 80%" },
-      });
-    }, sectionRef);
-    return () => ctx.revert();
-  }, []);
-
-  useEffect(() => {
-    if (!listRef.current) return;
-    const items = listRef.current.querySelectorAll(".module-item");
-    gsap.fromTo(items, { x: 20, opacity: 0 }, { x: 0, opacity: 1, stagger: 0.05, duration: 0.3, ease: "power2.out" });
-  }, [active]);
+  const [active, setActive] = useState<Category>("System");
 
   return (
-    <section ref={sectionRef} className="relative px-6 py-32">
+    <section className="relative px-6 py-24 md:py-32">
       <div className="mx-auto max-w-5xl">
         <div className="mb-12 text-center">
-          <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">
+          <h2 className="mb-4 text-3xl font-bold text-[#CDD6F4] md:text-5xl">
             26 modules. <span className="text-[#89B4FA]">Zero bloat.</span>
           </h2>
           <p className="text-lg text-[#A6ADC8]">Pick what you need. Ignore the rest. Each one tested on X11, Wayland, and macOS.</p>
         </div>
 
-        {/* Tabs */}
         <div className="mb-8 flex flex-wrap justify-center gap-2">
           {catKeys.map((cat) => (
-            <button key={cat} onClick={() => setActive(cat)} className={`rounded-full px-4 py-2 text-sm font-medium transition-all duration-300 ${active === cat ? "bg-[#CBA6F7] text-[#1E1E2E]" : "border border-[#313244] text-[#A6ADC8] hover:border-[#585B70] hover:text-[#CDD6F4]"}`}>
+            <button key={cat} onClick={() => setActive(cat)} className={`rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 ${active === cat ? "bg-[#CBA6F7] text-[#1E1E2E]" : "border border-[#313244] text-[#A6ADC8] hover:border-[#585B70] hover:text-[#CDD6F4]"}`}>
               {cat} <span className="ml-1 text-xs opacity-70">({categories[cat].length})</span>
             </button>
           ))}
         </div>
 
-        {/* Module list */}
-        <div ref={listRef} className="grid gap-3 sm:grid-cols-2">
-          {categories[active].map((m, i) => (
-            <div key={m.name} className="module-item flex items-center gap-3 rounded-xl border border-[#313244]/40 bg-[#181825]/40 px-4 py-3 transition-all duration-300 hover:border-[#CBA6F7]/20 hover:bg-[#181825]/80">
+        <div className="grid gap-3 sm:grid-cols-2">
+          {categories[active].map((m) => (
+            <div key={m.name} className="flex items-center gap-3 rounded-xl border border-[#313244]/40 bg-[#181825]/40 px-4 py-3 transition-all duration-200 hover:border-[#CBA6F7]/20 hover:bg-[#181825]/80">
               <code className="rounded bg-[#313244] px-2 py-0.5 text-xs text-[#CBA6F7]">{m.name}</code>
               <span className="text-sm text-[#A6ADC8]">{m.desc}</span>
             </div>

--- a/website/components/landing/problem-solution.tsx
+++ b/website/components/landing/problem-solution.tsx
@@ -1,6 +1,4 @@
 "use client";
-import { useEffect, useRef } from "react";
-import { gsap, ScrollTrigger } from "@/lib/gsap";
 
 const problems = [
   { icon: "💀", text: "10 scripts from 10 repos. None themed." },
@@ -17,52 +15,33 @@ const solutions = [
 ];
 
 export function ProblemSolution() {
-  const sectionRef = useRef<HTMLElement>(null);
-
-  useEffect(() => {
-    if (!sectionRef.current) return;
-    const ctx = gsap.context(() => {
-      gsap.from(".problem-card", {
-        x: -60, opacity: 0, stagger: 0.12, duration: 0.7,
-        scrollTrigger: { trigger: sectionRef.current, start: "top 75%" },
-      });
-      gsap.from(".solution-card", {
-        x: 60, opacity: 0, stagger: 0.12, duration: 0.7,
-        scrollTrigger: { trigger: sectionRef.current, start: "top 75%" },
-      });
-    }, sectionRef);
-    return () => ctx.revert();
-  }, []);
-
   return (
-    <section ref={sectionRef} className="relative px-6 py-32">
+    <section className="relative px-6 py-24 md:py-32">
       <div className="mx-auto max-w-6xl">
         <div className="mb-16 text-center">
-          <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">
-            The <span className="line-through text-[#F38BA8]/60">mess</span> you know
+          <h2 className="mb-4 text-3xl font-bold text-[#CDD6F4] md:text-5xl">
+            The <span className="line-through decoration-[#F38BA8]/60 decoration-2">mess</span> you know
           </h2>
           <p className="text-lg text-[#A6ADC8]">vs. the system you deserve</p>
         </div>
 
         <div className="grid gap-8 md:grid-cols-2">
-          {/* Problems */}
           <div className="space-y-4">
             <div className="mb-6 inline-block rounded-full border border-[#F38BA8]/20 bg-[#F38BA8]/5 px-4 py-1.5 text-sm text-[#F38BA8]">before kall</div>
             {problems.map((p, i) => (
-              <div key={i} className="problem-card flex items-center gap-4 rounded-xl border border-[#313244]/50 bg-[#181825]/50 p-4 opacity-60">
-                <span className="text-2xl">{p.icon}</span>
-                <span className="text-[#A6ADC8]">{p.text}</span>
+              <div key={i} className="flex items-center gap-4 rounded-xl border border-[#313244]/50 bg-[#181825]/50 p-4 text-[#A6ADC8]">
+                <span className="text-2xl shrink-0">{p.icon}</span>
+                <span>{p.text}</span>
               </div>
             ))}
           </div>
 
-          {/* Solutions */}
           <div className="space-y-4">
             <div className="mb-6 inline-block rounded-full border border-[#A6E3A1]/20 bg-[#A6E3A1]/5 px-4 py-1.5 text-sm text-[#A6E3A1]">with kall</div>
             {solutions.map((s, i) => (
-              <div key={i} className="solution-card flex items-center gap-4 rounded-xl border border-[#A6E3A1]/10 bg-[#181825]/80 p-4 transition-all duration-300 hover:border-[#A6E3A1]/30 hover:shadow-[0_0_20px_rgba(166,227,161,0.05)]">
-                <span className="text-2xl">{s.icon}</span>
-                <span className="text-[#CDD6F4]">{s.text}</span>
+              <div key={i} className="flex items-center gap-4 rounded-xl border border-[#A6E3A1]/10 bg-[#181825]/80 p-4 text-[#CDD6F4] transition-all duration-300 hover:border-[#A6E3A1]/30 hover:shadow-[0_0_20px_rgba(166,227,161,0.05)]">
+                <span className="text-2xl shrink-0">{s.icon}</span>
+                <span>{s.text}</span>
               </div>
             ))}
           </div>

--- a/website/components/landing/themes.tsx
+++ b/website/components/landing/themes.tsx
@@ -1,6 +1,4 @@
 "use client";
-import { useEffect, useRef } from "react";
-import { gsap } from "@/lib/gsap";
 
 const palettes = [
   { name: "Catppuccin Mocha", colors: ["#1E1E2E", "#CDD6F4", "#CBA6F7", "#89B4FA", "#A6E3A1"] },
@@ -12,28 +10,16 @@ const palettes = [
 ];
 
 export function Themes() {
-  const sectionRef = useRef<HTMLElement>(null);
-  useEffect(() => {
-    if (!sectionRef.current) return;
-    const ctx = gsap.context(() => {
-      gsap.from(".palette-card", {
-        y: 40, opacity: 0, stagger: 0.08, duration: 0.6,
-        scrollTrigger: { trigger: sectionRef.current, start: "top 80%" },
-      });
-    }, sectionRef);
-    return () => ctx.revert();
-  }, []);
-
   return (
-    <section ref={sectionRef} className="relative px-6 py-32">
+    <section className="relative px-6 py-24 md:py-32">
       <div className="mx-auto max-w-5xl">
         <div className="mb-12 text-center">
-          <h2 className="mb-4 text-4xl font-bold text-[#CDD6F4] md:text-5xl">Six palettes. <span className="text-[#F9E2AF]">Or your wallpaper.</span></h2>
+          <h2 className="mb-4 text-3xl font-bold text-[#CDD6F4] md:text-5xl">Six palettes. <span className="text-[#F9E2AF]">Or your wallpaper.</span></h2>
           <p className="text-lg text-[#A6ADC8]">Static palettes ship out of the box. Enable wallbash and your wallpaper becomes your theme.</p>
         </div>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {palettes.map((p) => (
-            <div key={p.name} className="palette-card group rounded-xl border border-[#313244]/40 bg-[#181825]/40 p-4 transition-all duration-300 hover:border-[#585B70] hover:bg-[#181825]/80">
+            <div key={p.name} className="group rounded-xl border border-[#313244]/40 bg-[#181825]/40 p-4 transition-all duration-300 hover:border-[#585B70] hover:bg-[#181825]/80">
               <div className="mb-3 flex gap-2">
                 {p.colors.map((c, j) => (
                   <div key={j} className="h-8 w-8 rounded-lg transition-transform duration-300 group-hover:scale-110" style={{ backgroundColor: c }} />


### PR DESCRIPTION
## Fixes

- **Problem/Solution section**: 'with kall' cards were invisible (GSAP ScrollTrigger set opacity:0 before trigger fired)
- **Features section**: all 6 feature cards were invisible (same issue)
- **Themes section**: all 6 palette cards were invisible (same issue)
- **Module tabs**: removed janky GSAP fromTo animation on tab switch, now instant
- **Backends**: removed auto-cycling (was confusing), kept manual click
- **Install CTA**: removed GSAP dependency (static section, no animation needed)

## Root cause
GSAP `ScrollTrigger` with `.from({opacity: 0})` sets initial state to invisible. If ScrollTrigger hasn't fired (element below viewport), content stays hidden forever. Removed ScrollTrigger from all sections — content is now always visible. GSAP hero animation (letter reveal on load) still works.

## Sections now visible
- Problem/Solution: both columns show cards
- Features: 6 cards in bento grid
- Module Catalog: tabs work with instant switch
- Backends: manual click selection
- Themes: 6 palette cards with color swatches
- Install CTA: static, always visible